### PR TITLE
Improved python 2.6 compatibility

### DIFF
--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -61,7 +61,7 @@ def check_encoding_chars(encoding_chars):
     """
     if not isinstance(encoding_chars, collections.MutableMapping):
         raise InvalidEncodingChars
-    required = {'FIELD', 'COMPONENT', 'SUBCOMPONENT', 'REPETITION', 'ESCAPE'}
+    required = set(['FIELD', 'COMPONENT', 'SUBCOMPONENT', 'REPETITION', 'ESCAPE'])
     missing = required - set(encoding_chars.keys())
     if missing:
         raise InvalidEncodingChars('Missing required encoding chars')
@@ -308,8 +308,8 @@ def find_reference(name, element_types, version):
 
 def _discover_libraries():
     current_dir = os.path.dirname(__file__)
-    return {o[1:].replace("_", "."): "hl7apy.{}".format(o)
-            for o in os.listdir(current_dir) if o.startswith("v2_")}
+    return dict((o[1:].replace("_", "."), "hl7apy.{0}".format(o))
+            for o in os.listdir(current_dir) if o.startswith("v2_"))
 
 SUPPORTED_LIBRARIES = _discover_libraries()
 

--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -466,11 +466,11 @@ class ElementFinder(object):
         if content_type in ('sequence', 'choice'):
             children = reference[1]
             structure = collections.OrderedDict()
-            repetitions = {child_name:cardinality for child_name, cardinality in children}
+            repetitions = dict((child_name, cardinality) for (child_name, cardinality) in children)
             for c in children:
                 child_name, cardinality = c
                 structure[child_name] = find_reference(child_name, element.child_classes, element.version)
-            data['structure_by_longname'] = {e['ref'][2]: e for e in structure.values() if e['ref'][0] == 'leaf'}
+            data['structure_by_longname'] = dict((e['ref'][2], e) for e in structure.values() if e['ref'][0] == 'leaf')
             data['structure_by_name'] = structure
             data['repetitions'] = repetitions
         elif content_type == 'leaf':


### PR DESCRIPTION
We are no longer using dictionary comprehension or set comprehension due
to the fact they were both introduced in Python 2.7. A lot of server
machines still run CentOS 6 which, in turn, only has Python 2.6
available by default. Please note that people will need to install
importlib and possibly some other libraries before hl7apy will work.
