### PR TITLE
2to3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: python
 python:
   - "2.7"
 before_install:
-  pip install coveralls
+  pip install coveralls future six
 # command to install dependencies
 install:
   - python setup.py install
 # command to run tests
-script: 
+script:
   - nosetests tests hl7apy --with-doctest --with-coverage --cover-package hl7apy
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - python setup.py install
 # command to run tests
 script:
-  - nosetests tests hl7apy --with-doctest --with-coverage --cover-package hl7apy
+  - nosetests tests hl7apy --with-doctest --doctest-options="+IGNORE_EXCEPTION_DETAIL" --with-coverage --cover-package hl7apy
 after_success:
   - coveralls
 #just build master branch

--- a/docs/_themes/sphinx_rtd_theme/__init__.py
+++ b/docs/_themes/sphinx_rtd_theme/__init__.py
@@ -3,6 +3,13 @@
 From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import str
 import os
 

--- a/docs/_themes/sphinx_rtd_theme/__init__.py
+++ b/docs/_themes/sphinx_rtd_theme/__init__.py
@@ -3,6 +3,7 @@
 From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 
 """
+from builtins import str
 import os
 
 VERSION = (0, 1, 5)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 sys.path.append('..')
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -177,7 +177,7 @@ You can get the ER7-encoded string of ``Message``, ``Group``, ``Segment``, ``Fie
 
   pid = "PID|1||566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004~444-333-222|||M\r"
   segment = parse_segment(pid)
-  print segment.to_er7()
+  print(segment.to_er7())
 
 You can also use custom encoding chars:
 
@@ -188,7 +188,7 @@ You can also use custom encoding chars:
   custom_chars = {'FIELD': '!', 'COMPONENT': '@', 'SUBCOMPONENT': '%', 'REPETITION': '~', 'ESCAPE': '$'}
   pid = "PID|1||566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004~444-333-222|||M\r"
   segment = parse_segment(pid)
-  print segment.to_er7(encoding_chars=custom_chars)
+  print(segment.to_er7(encoding_chars=custom_chars))
 
 For ``Message`` objects, you can get the string ready to be sent using mllp, by calling :meth:`hl7apy.Element.to_mllp` method:
 

--- a/examples/lab62/actor.py
+++ b/examples/lab62/actor.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import object
 import uuid
 

--- a/examples/lab62/actor.py
+++ b/examples/lab62/actor.py
@@ -19,6 +19,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import uuid
 
 from hl7apy.core import Message, Segment
@@ -45,17 +46,17 @@ class LB(object):
     @staticmethod
     def receive(message):
         # print to stdout the data received
-        print "Received by LB"
+        print("Received by LB")
         try:
             # parse the incoming HL7 message
             m = parse_message(message, find_groups=False)
         except:
-            print 'parsing failed', repr(message)
+            print('parsing failed', repr(message))
         else:
-            print "Message type:", m.MSH.message_type.to_er7()
-            print "Message content:", repr(m.to_er7())
+            print("Message type:", m.MSH.message_type.to_er7())
+            print("Message content:", repr(m.to_er7()))
             surname, name = m.PID.PID_5.family_name.to_er7(), m.PID.PID_5.given_name.to_er7()
-            print "Patient data:", surname, name
+            print("Patient data:", surname, name)
 
 class LIP(object):
     """
@@ -85,17 +86,17 @@ class LIP(object):
         :param message: incoming message
         :return: response encoded to ER7 - it can be a NAK or RSP_K11 message
         """
-        print "Received by LIP", repr(message)
+        print("Received by LIP", repr(message))
 
         try:
             # parse the incoming message
             m = parse_message(message, find_groups=False)
         except:
-            print 'parsing failed', repr(message)
+            print('parsing failed', repr(message))
             response = LIP.nak()
         else:
-            print "Message type:", m.MSH.message_type.to_er7()
-            print "Message content:", repr(m.to_er7())
+            print("Message type:", m.MSH.message_type.to_er7())
+            print("Message content:", repr(m.to_er7()))
             if m.MSH.MSH_9.MSH_9_3.to_er7() == 'QBP_Q11':
                 # create a new RSP_K11 message
                 response = Message("RSP_K11")

--- a/examples/lab62/actor.py
+++ b/examples/lab62/actor.py
@@ -20,6 +20,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from builtins import object
 import uuid
 
 from hl7apy.core import Message, Segment

--- a/examples/lab62/client.py
+++ b/examples/lab62/client.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import socket
 
 from actor import LB

--- a/examples/lab62/server.py
+++ b/examples/lab62/server.py
@@ -20,6 +20,10 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object

--- a/examples/lab62/server.py
+++ b/examples/lab62/server.py
@@ -20,7 +20,10 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
-import SocketServer
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import socketserver
 import re
 
 from actor import LIP
@@ -48,7 +51,7 @@ class MLLProtocol(object):
             message = matched.groups()[0]
         return message
 
-class MLLPServer(SocketServer.StreamRequestHandler):
+class MLLPServer(socketserver.StreamRequestHandler):
     """
     Simplistic implementation of a TCP server implementing the MLLP protocol
 
@@ -75,5 +78,5 @@ class MLLPServer(SocketServer.StreamRequestHandler):
 if __name__ == "__main__":
     HOST, PORT = "localhost", 6000
 
-    server = SocketServer.TCPServer((HOST, PORT), MLLPServer)
+    server = socketserver.TCPServer((HOST, PORT), MLLPServer)
     server.serve_forever()

--- a/examples/lab62/server.py
+++ b/examples/lab62/server.py
@@ -19,6 +19,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import SocketServer
 import re
 
@@ -59,7 +60,7 @@ class MLLPServer(SocketServer.StreamRequestHandler):
         while True:
             char = self.rfile.read(1)
             if not char:
-                print 'client disconnected'
+                print('client disconnected')
                 break
             line += char
             # check if incoming buffer contains a HL7 message

--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -1,3 +1,8 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 # -*- coding: utf-8 -*-
@@ -309,7 +314,7 @@ def find_reference(name, element_types, version):
 
 
 def load_message_profile(path):
-    with open(path) as f:
+    with open(path, 'rb') as f:
         mp = pickle.load(f)
 
     return mp

--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -96,7 +96,7 @@ def get_default_encoding_chars():
     :rtype: ``dict``
     :returns: the encoding chars (see :func:`hl7apy.set_default_encoding_chars`)
 
-    >>> print get_default_encoding_chars()['FIELD']
+    >>> print(get_default_encoding_chars()['FIELD'])
     |
     """
     return _DEFAULT_ENCODING_CHARS
@@ -109,7 +109,7 @@ def get_default_version():
     :rtype: ``str``
     :returns: the default version
 
-    >>> print get_default_version()
+    >>> print(get_default_version())
     2.5
     """
     return _DEFAULT_VERSION
@@ -122,7 +122,7 @@ def get_default_validation_level():
     :rtype: ``str``
     :returns: the default validation level
 
-    >>> print get_default_validation_level()
+    >>> print(get_default_validation_level())
     2
     """
     return _DEFAULT_VALIDATION_LEVEL
@@ -139,9 +139,9 @@ def set_default_validation_level(validation_level):
     >>> set_default_validation_level(3)
     Traceback (most recent call last):
         ...
-    UnknownValidationLevel
+    hl7apy.exceptions.UnknownValidationLevel
     >>> set_default_validation_level(VALIDATION_LEVEL.TOLERANT)
-    >>> print get_default_validation_level()
+    >>> print(get_default_validation_level())
     2
     """
     check_validation_level(validation_level)
@@ -162,9 +162,9 @@ def set_default_version(version):
     >>> set_default_version('22')
     Traceback (most recent call last):
         ...
-    UnsupportedVersion: The version 22 is not supported
+    hl7apy.exceptions.UnsupportedVersion: The version 22 is not supported
     >>> set_default_version('2.3')
-    >>> print get_default_version()
+    >>> print(get_default_version())
     2.3
     """
     check_version(version)
@@ -205,10 +205,10 @@ def set_default_encoding_chars(encoding_chars):
     >>> set_default_encoding_chars({'FIELD': '!'})
     Traceback (most recent call last):
         ...
-    InvalidEncodingChars: Missing required encoding chars
+    hl7apy.exceptions.InvalidEncodingChars: Missing required encoding chars
     >>> set_default_encoding_chars({'FIELD': '!', 'COMPONENT': 'C', 'SUBCOMPONENT': 'S', \
                                     'REPETITION': 'R', 'ESCAPE': '\\\\'})
-    >>> print get_default_encoding_chars()['FIELD']
+    >>> print(get_default_encoding_chars()['FIELD'])
     !
     """
     check_encoding_chars(encoding_chars)
@@ -268,12 +268,12 @@ def load_reference(name, element_type, version):
     >>> load_reference('UNKNOWN', 'Segment', '2.5')
     Traceback (most recent call last):
     ...
-    ChildNotFound: No child named UNKNOWN
+    hl7apy.exceptions.ChildNotFound: No child named UNKNOWN
     >>> r = load_reference('ADT_A01', 'Message', '2.5')
-    >>> print r[0]
+    >>> print(r[0])
     sequence
     >>> r = load_reference('MSH_3', 'Field', '2.5')
-    >>> print r[0]
+    >>> print(r[0])
     leaf
     """
     lib = load_library(version)
@@ -299,13 +299,13 @@ def find_reference(name, element_types, version):
     >>> find_reference('UNKNOWN', (Segment, ), '2.5')
     Traceback (most recent call last):
     ...
-    ChildNotFound: No child named UNKNOWN
+    hl7apy.exceptions.ChildNotFound: No child named UNKNOWN
     >>> find_reference('ADT_A01', (Segment,),  '2.5')
     Traceback (most recent call last):
     ...
-    ChildNotFound: No child named ADT_A01
+    hl7apy.exceptions.ChildNotFound: No child named ADT_A01
     >>> r = find_reference('ADT_A01', (Message,),  '2.5')
-    >>> print r['name'], r['cls']
+    >>> print(r['name'], r['cls'])
     ADT_A01 <class 'hl7apy.core.Message'>
     """
     lib = load_library(version)

--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -1,3 +1,5 @@
+from future import standard_library
+standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2012-2015, CRS4
@@ -23,7 +25,7 @@ import os
 import sys
 import collections
 import importlib
-import cPickle
+import pickle
 
 from hl7apy.exceptions import UnsupportedVersion, InvalidEncodingChars, UnknownValidationLevel
 from hl7apy.consts import DEFAULT_ENCODING_CHARS, DEFAULT_VERSION, VALIDATION_LEVEL
@@ -53,7 +55,7 @@ def check_encoding_chars(encoding_chars):
     if missing:
         raise InvalidEncodingChars('Missing required encoding chars')
 
-    values = [v for k, v in encoding_chars.items() if k in required]
+    values = [v for k, v in list(encoding_chars.items()) if k in required]
     if len(values) > len(set(values)):
         raise InvalidEncodingChars('Found duplicate encoding chars')
 
@@ -308,7 +310,7 @@ def find_reference(name, element_types, version):
 
 def load_message_profile(path):
     with open(path) as f:
-        mp = cPickle.load(f)
+        mp = pickle.load(f)
 
     return mp
 

--- a/hl7apy/base_datatypes.py
+++ b/hl7apy/base_datatypes.py
@@ -31,7 +31,15 @@
     >>> f = FT('some useful information')
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import object
+import functools
 
 import re
 import numbers
@@ -146,7 +154,7 @@ class TextualDataType(BaseDataType):
                 else:
                     raise InvalidHighlightRange(x, y)
 
-            self.highlights = sorted(self.highlights, cmp=_sort_highlights)
+            self.highlights = sorted(self.highlights, key=functools.cmp_to_key(_sort_highlights))
             words = list(value)
             offset = 0
             for hl in self.highlights:

--- a/hl7apy/base_datatypes.py
+++ b/hl7apy/base_datatypes.py
@@ -31,6 +31,7 @@
     >>> f = FT('some useful information')
 
 """
+from builtins import object
 
 import re
 import numbers

--- a/hl7apy/consts.py
+++ b/hl7apy/consts.py
@@ -22,6 +22,7 @@
 """
 HL7apy - Constants
 """
+from builtins import object
 
 #: number of expected separators
 N_SEPS = 4

--- a/hl7apy/consts.py
+++ b/hl7apy/consts.py
@@ -22,6 +22,13 @@
 """
 HL7apy - Constants
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import object
 
 #: number of expected separators

--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -22,9 +22,17 @@
 """
 HL7apy - core classes
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import str
 from builtins import range
 from builtins import object
+from six import string_types
 
 import re
 import collections
@@ -293,7 +301,7 @@ class ElementList(collections.MutableSequence):
         reference = None if name is None else self.element.find_child_reference(name)
         child_ref, child_name = (None, None) if reference is None else (reference['ref'], reference['name'])
 
-        if isinstance(value, str):  # if the value is a basestring, parse it
+        if isinstance(value, string_types):  # if the value is a basestring, parse it
             child = self.element.parse_child(value, child_name=child_name, reference=child_ref)
         elif isinstance(value, Element):  # it is already an instance of Element
             child = value
@@ -301,6 +309,7 @@ class ElementList(collections.MutableSequence):
             child = self.create_element(name, False, reference)
             child.value = value
         else:
+            print(type(value))
             raise ChildNotValid(value, child_name)
 
         if child.name != child_name:  # e.g. message.pid = Segment('SPM') is forbidden
@@ -621,7 +630,7 @@ class Element(object):
 
         check_validation_level(validation_level)
         check_version(version)
-        
+
         self.validation_level = validation_level
         self.name = name.upper() if name is not None else None
         self.version = version
@@ -809,7 +818,7 @@ class Element(object):
     def _find_structure(self, reference=None):
         if self.name is not None:
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.items():
+            for k, v in list(structure.items()):
                 setattr(self, k, v)
 
     def _is_valid_child(self, child):
@@ -906,7 +915,7 @@ class SupportComplexDataType(Element):
                 datatype not in ('varies', None, self.datatype):
             reference = load_reference(datatype, 'Component', self.version)
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.items():
+            for k, v in list(structure.items()):
                 setattr(self, k, v)
 
         if hasattr(self, 'children') and len(self.children) >= 1:

--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -22,6 +22,9 @@
 """
 HL7apy - core classes
 """
+from builtins import str
+from builtins import range
+from builtins import object
 
 import re
 import collections
@@ -290,7 +293,7 @@ class ElementList(collections.MutableSequence):
         reference = None if name is None else self.element.find_child_reference(name)
         child_ref, child_name = (None, None) if reference is None else (reference['ref'], reference['name'])
 
-        if isinstance(value, basestring):  # if the value is a basestring, parse it
+        if isinstance(value, str):  # if the value is a basestring, parse it
             child = self.element.parse_child(value, child_name=child_name, reference=child_ref)
         elif isinstance(value, Element):  # it is already an instance of Element
             child = value
@@ -576,11 +579,11 @@ class ElementFinder(object):
             data['ordered_children'] = ordered_children
             data['structure_by_name'] = structure
             if is_profile is False:
-                data['structure_by_longname'] = {e['ref'][2]: e for e in structure.values()
+                data['structure_by_longname'] = {e['ref'][2]: e for e in list(structure.values())
                                                  if e['ref'][0] == 'leaf'}
             else:
                 # in this case the len is 6 and not 5 as above because here the first is 'mp'
-                data['structure_by_longname'] = {e['ref'][7]: e for e in structure.values()
+                data['structure_by_longname'] = {e['ref'][7]: e for e in list(structure.values())
                                                  if e['ref'][1] == 'leaf' or len(e['ref']) > 6}
 
         if content_type == 'leaf' or (is_profile and len(reference) > 5):
@@ -806,7 +809,7 @@ class Element(object):
     def _find_structure(self, reference=None):
         if self.name is not None:
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.iteritems():
+            for k, v in structure.items():
                 setattr(self, k, v)
 
     def _is_valid_child(self, child):
@@ -903,7 +906,7 @@ class SupportComplexDataType(Element):
                 datatype not in ('varies', None, self.datatype):
             reference = load_reference(datatype, 'Component', self.version)
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.iteritems():
+            for k, v in structure.items():
                 setattr(self, k, v)
 
         if hasattr(self, 'children') and len(self.children) >= 1:
@@ -1111,7 +1114,7 @@ class SubComponent(CanBeVaries):
         if value is None:
             self._value = None
         else:
-            if value and isinstance(value, basestring):
+            if value and isinstance(value, str):
                 self._value = datatype_factory(self.datatype, value, self.version,
                                                self.validation_level)
             elif not value or isinstance(value, BaseDataType):
@@ -1438,7 +1441,7 @@ class Field(SupportComplexDataType):
 
     def _get_children(self, trailing=False):
         if self.datatype == 'varies':
-            children = [self.children.indexes['VARIES_{0}'.format(i+1)] for i in xrange(len(self.children))]
+            children = [self.children.indexes['VARIES_{0}'.format(i+1)] for i in range(len(self.children))]
             children = _remove_trailing(children)
             children.extend([[c] for c in self.children if c.is_unknown()])
             return children
@@ -1699,7 +1702,7 @@ class Segment(Element):
     def _get_children(self, trailing=False):
         children = self.children.get_ordered_children()
         if self.allow_infinite_children:
-            for i in xrange(self._last_allowed_child_index + 1, self._last_child_index + 1):
+            for i in range(self._last_allowed_child_index + 1, self._last_child_index + 1):
                 children.append(self.children.indexes.get('{}_{}'.format(self.name, i), None))
         children.extend([c for c in self.children.get_children() if c[0].name in (None, 'ST')])
         if not trailing:

--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -117,11 +117,11 @@ class ElementProxy(collections.Sequence):
     in order to support the following API:
 
     >>> m = Message("OML_O33")
-    >>> print m.msh
+    >>> print(m.msh)
     [<Segment MSH>]
-    >>> print isinstance(m.msh, ElementProxy)
+    >>> print(isinstance(m.msh, ElementProxy))
     True
-    >>> print isinstance(m.msh.msh_7, ElementProxy)
+    >>> print(isinstance(m.msh.msh_7, ElementProxy))
     True
     """
     cls_attrs = ('element_list', 'list', 'element_name')
@@ -671,7 +671,7 @@ class Element(object):
         >>> f = Field('PID_5')
         >>> f.value = 'EVERYMAN^ADAM'
         >>> s.add(f)
-        >>> print s.to_er7()
+        >>> print(s.to_er7())
         PID|||||EVERYMAN^ADAM
         """
         self.children.append(obj)
@@ -1108,7 +1108,7 @@ class SubComponent(CanBeVaries):
 
         >>> s = SubComponent("CE_1")
         >>> s.value = "IDENTIFIER"
-        >>> print s.to_er7()
+        >>> print(s.to_er7())
         IDENTIFIER
         """
 
@@ -1223,9 +1223,9 @@ class Component(SupportComplexDataType, CanBeVaries):
 
         >>> c = Component(datatype='CE')
         >>> ce_1 = c.add_subcomponent('CE_1')
-        >>> print ce_1
+        >>> print(ce_1)
         <SubComponent CE_1>
-        >>> print ce_1 in c.children
+        >>> print(ce_1 in c.children)
         True
         """
         if self.is_unknown() and is_base_datatype(self.datatype):
@@ -1244,7 +1244,7 @@ class Component(SupportComplexDataType, CanBeVaries):
         >>> s2 = SubComponent(name='CWE_4', value='ALT_ID')
         >>> c.add(s)
         >>> c.add(s2)
-        >>> print c.to_er7()
+        >>> print(c.to_er7())
         EXAMPLE_ID&&&ALT_ID
         """
         # base datatype components can't have more than one child
@@ -1345,7 +1345,7 @@ class Field(SupportComplexDataType):
         :return: an instance of :class:`Component <hl7apy.core.Component>`
 
         >>> s = Field('PID_5')
-        >>> print s.add_component('XPN_2')
+        >>> print(s.add_component('XPN_2'))
         <Component XPN_2 (GIVEN_NAME) of type ST>
         """
         return self.children.create_element(name)
@@ -1379,7 +1379,7 @@ class Field(SupportComplexDataType):
         >>> c = Component('XPN_2')
         >>> c.value = 'ADAM'
         >>> f.add(c)
-        >>> print f.to_er7()
+        >>> print(f.to_er7())
         EVERYMAN^ADAM
         """
         # base datatype components can't have more than one child
@@ -1414,7 +1414,7 @@ class Field(SupportComplexDataType):
 
         >>> msh_9 = Field("MSH_9")
         >>> msh_9.value = "ADT^A01^ADT_A01"
-        >>> print msh_9.to_er7()
+        >>> print(msh_9.to_er7())
         ADT^A01^ADT_A01
         """
         if encoding_chars is None:
@@ -1597,7 +1597,7 @@ class Segment(Element):
         :return: an instance of :class:`Field <hl7apy.core.Field>`
 
         >>> s = Segment('PID')
-        >>> print s.add_field('PID_1')
+        >>> print(s.add_field('PID_1'))
         <Field PID_1 (SET_ID_PID) of type SI>
         """
         return self.children.create_element(name)
@@ -1667,7 +1667,7 @@ class Segment(Element):
         >>> pid = Segment("PID")
         >>> pid.pid_1 = '1'
         >>> pid.pid_5 = "EVERYMAN^ADAM"
-        >>> print pid.to_er7()
+        >>> print(pid.to_er7())
         PID|1||||EVERYMAN^ADAM
         """
         if encoding_chars is None:
@@ -1762,9 +1762,9 @@ class Group(Element):
 
         >>> m = Message('QBP_Q11')
         >>> qpd = m.add_segment('QPD')
-        >>> print qpd
+        >>> print(qpd)
         <Segment QPD>
-        >>> print qpd in m.children
+        >>> print(qpd in m.children)
         True
         """
         return self.children.create_element(name)
@@ -1778,9 +1778,9 @@ class Group(Element):
 
         >>> m = Message('OML_O33')
         >>> patient = m.add_group('OML_O33_PATIENT')
-        >>> print patient
+        >>> print(patient)
         <Group OML_O33_PATIENT>
-        >>> print patient in m.children
+        >>> print(patient in m.children)
         True
         """
 

--- a/hl7apy/exceptions.py
+++ b/hl7apy/exceptions.py
@@ -41,7 +41,7 @@ class ParserError(HL7apyException):
     >>> m = parse_message('NOTHL7')
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.ParserError: Invalid message
+    ParserError: Invalid message
     """
 
 
@@ -60,7 +60,7 @@ class ValidationError(HL7apyException):
     >>> parse_message(message, validation_level=VALIDATION_LEVEL.STRICT, force_validation=True)
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.ValidationError: Missing required child ADT_A01.PV1
+    ValidationError: Missing required child ADT_A01.PV1
     """
 
 
@@ -78,7 +78,7 @@ class UnsupportedVersion(HL7apyException):
     >>> set_default_version("2.0")
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.UnsupportedVersion: The version 2.0 is not supported
+    UnsupportedVersion: The version 2.0 is not supported
     """
     def __init__(self, version):
         self.version = version
@@ -96,7 +96,7 @@ class ChildNotFound(HL7apyException):
     >>> s.unknown = Field()
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.ChildNotFound: No child named UNKNOWN
+    ChildNotFound: No child named UNKNOWN
     """
     def __init__(self, name):
         self.name = name
@@ -114,7 +114,7 @@ class ChildNotValid(HL7apyException):
     >>> s.pid_1 = Field('PID_34')
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.ChildNotValid: <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
+    ChildNotValid: <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
     """
     def __init__(self, child, parent):
         self.child = child
@@ -134,7 +134,7 @@ class UnknownValidationLevel(HL7apyException):
     >>> set_default_validation_level(3)
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.UnknownValidationLevel
+    UnknownValidationLevel
     """
 
 
@@ -146,7 +146,7 @@ class OperationNotAllowed(HL7apyException):
     >>> s = Segment()
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.OperationNotAllowed: Cannot instantiate an unknown Segment
+    OperationNotAllowed: Cannot instantiate an unknown Segment
     """
 
 
@@ -162,7 +162,7 @@ class MaxChildLimitReached(HL7apyException):
     >>> m.add(Segment('MSH'))
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.MaxChildLimitReached: Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
+    MaxChildLimitReached: Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
     """
     def __init__(self, parent, child, limit):
         self.parent = parent
@@ -183,7 +183,7 @@ class MaxLengthReached(HL7apyException):
     >>> st = SI(value=11111, validation_level=VALIDATION_LEVEL.STRICT)
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.MaxLengthReached: The value 11111 exceed the max length: 4
+    MaxLengthReached: The value 11111 exceed the max length: 4
     """
     def __init__(self, value, limit):
         self.value = value
@@ -201,7 +201,7 @@ class InvalidName(HL7apyException):
     >>> Message('Unknown')
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidName: Invalid name for Message: UNKNOWN
+    InvalidName: Invalid name for Message: UNKNOWN
     """
     def __init__(self, cls, name):
         self.cls = cls
@@ -221,7 +221,7 @@ class InvalidDataType(HL7apyException):
     >>> datatype_factory('TN', '11 123456', version="2.5")
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidDataType: The datatype TN is not available for the given HL7 version
+    InvalidDataType: The datatype TN is not available for the given HL7 version
     """
     def __init__(self, datatype):
         self.datatype = datatype
@@ -241,7 +241,7 @@ class InvalidHighlightRange(HL7apyException):
     >>> s.to_er7()
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidHighlightRange: Invalid highlight range: 5 - 3
+    InvalidHighlightRange: Invalid highlight range: 5 - 3
     """
     def __init__(self, lower_bound, upper_bound):
         self.lower_bound = lower_bound
@@ -259,7 +259,7 @@ class InvalidDateFormat(HL7apyException):
     >>> DTM(value='10102013', out_format="%d%m%Y")
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidDateFormat: Invalid date format: %d%m%Y
+    InvalidDateFormat: Invalid date format: %d%m%Y
     """
     def __init__(self, out_format):
         self.format = out_format
@@ -276,7 +276,7 @@ class InvalidDateOffset(HL7apyException):
     >>> DTM(value='20131010', out_format="%Y%m%d", offset='+1300')
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidDateOffset: Invalid date offset: +1300
+    InvalidDateOffset: Invalid date offset: +1300
     """
     def __init__(self, offset):
         self.offset = offset
@@ -294,7 +294,7 @@ class InvalidMicrosecondsPrecision(HL7apyException):
     >>> DTM(value='20131010', microsec_precision=5)
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidMicrosecondsPrecision: Invalid microseconds precision. It must be between 1 and 4
+    InvalidMicrosecondsPrecision: Invalid microseconds precision. It must be between 1 and 4
     """
 
     def __str__(self):
@@ -311,7 +311,7 @@ class InvalidEncodingChars(HL7apyException):
     >>> m = Message('ADT_A01', encoding_chars=encoding_chars)
     Traceback (most recent call last):
     ...
-    hl7apy.exceptions.InvalidEncodingChars: <unprintable InvalidEncodingChars object>
+    InvalidEncodingChars: <unprintable InvalidEncodingChars object>
     """
     def __str__(self):
         return self.message if self.message else 'Invalid encoding chars'

--- a/hl7apy/exceptions.py
+++ b/hl7apy/exceptions.py
@@ -41,7 +41,7 @@ class ParserError(HL7apyException):
     >>> m = parse_message('NOTHL7')
     Traceback (most recent call last):
     ...
-    ParserError: Invalid message
+    hl7apy.exceptions.ParserError: Invalid message
     """
 
 
@@ -60,7 +60,7 @@ class ValidationError(HL7apyException):
     >>> parse_message(message, validation_level=VALIDATION_LEVEL.STRICT, force_validation=True)
     Traceback (most recent call last):
     ...
-    ValidationError: Missing required child ADT_A01.PV1
+    hl7apy.exceptions.ValidationError: Missing required child ADT_A01.PV1
     """
 
 
@@ -78,7 +78,7 @@ class UnsupportedVersion(HL7apyException):
     >>> set_default_version("2.0")
     Traceback (most recent call last):
     ...
-    UnsupportedVersion: The version 2.0 is not supported
+    hl7apy.exceptions.UnsupportedVersion: The version 2.0 is not supported
     """
     def __init__(self, version):
         self.version = version
@@ -96,7 +96,7 @@ class ChildNotFound(HL7apyException):
     >>> s.unknown = Field()
     Traceback (most recent call last):
     ...
-    ChildNotFound: No child named UNKNOWN
+    hl7apy.exceptions.ChildNotFound: No child named UNKNOWN
     """
     def __init__(self, name):
         self.name = name
@@ -114,7 +114,7 @@ class ChildNotValid(HL7apyException):
     >>> s.pid_1 = Field('PID_34')
     Traceback (most recent call last):
     ...
-    ChildNotValid: <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
+    hl7apy.exceptions.ChildNotValid: <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
     """
     def __init__(self, child, parent):
         self.child = child
@@ -134,7 +134,7 @@ class UnknownValidationLevel(HL7apyException):
     >>> set_default_validation_level(3)
     Traceback (most recent call last):
     ...
-    UnknownValidationLevel
+    hl7apy.exceptions.UnknownValidationLevel
     """
 
 
@@ -146,7 +146,7 @@ class OperationNotAllowed(HL7apyException):
     >>> s = Segment()
     Traceback (most recent call last):
     ...
-    OperationNotAllowed: Cannot instantiate an unknown Segment
+    hl7apy.exceptions.OperationNotAllowed: Cannot instantiate an unknown Segment
     """
 
 
@@ -162,7 +162,7 @@ class MaxChildLimitReached(HL7apyException):
     >>> m.add(Segment('MSH'))
     Traceback (most recent call last):
     ...
-    MaxChildLimitReached: Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
+    hl7apy.exceptions.MaxChildLimitReached: Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
     """
     def __init__(self, parent, child, limit):
         self.parent = parent
@@ -183,7 +183,7 @@ class MaxLengthReached(HL7apyException):
     >>> st = SI(value=11111, validation_level=VALIDATION_LEVEL.STRICT)
     Traceback (most recent call last):
     ...
-    MaxLengthReached: The value 11111 exceed the max length: 4
+    hl7apy.exceptions.MaxLengthReached: The value 11111 exceed the max length: 4
     """
     def __init__(self, value, limit):
         self.value = value
@@ -201,7 +201,7 @@ class InvalidName(HL7apyException):
     >>> Message('Unknown')
     Traceback (most recent call last):
     ...
-    InvalidName: Invalid name for Message: UNKNOWN
+    hl7apy.exceptions.InvalidName: Invalid name for Message: UNKNOWN
     """
     def __init__(self, cls, name):
         self.cls = cls
@@ -221,7 +221,7 @@ class InvalidDataType(HL7apyException):
     >>> datatype_factory('TN', '11 123456', version="2.5")
     Traceback (most recent call last):
     ...
-    InvalidDataType: The datatype TN is not available for the given HL7 version
+    hl7apy.exceptions.InvalidDataType: The datatype TN is not available for the given HL7 version
     """
     def __init__(self, datatype):
         self.datatype = datatype
@@ -241,7 +241,7 @@ class InvalidHighlightRange(HL7apyException):
     >>> s.to_er7()
     Traceback (most recent call last):
     ...
-    InvalidHighlightRange: Invalid highlight range: 5 - 3
+    hl7apy.exceptions.InvalidHighlightRange: Invalid highlight range: 5 - 3
     """
     def __init__(self, lower_bound, upper_bound):
         self.lower_bound = lower_bound
@@ -259,7 +259,7 @@ class InvalidDateFormat(HL7apyException):
     >>> DTM(value='10102013', out_format="%d%m%Y")
     Traceback (most recent call last):
     ...
-    InvalidDateFormat: Invalid date format: %d%m%Y
+    hl7apy.exceptions.InvalidDateFormat: Invalid date format: %d%m%Y
     """
     def __init__(self, out_format):
         self.format = out_format
@@ -276,7 +276,7 @@ class InvalidDateOffset(HL7apyException):
     >>> DTM(value='20131010', out_format="%Y%m%d", offset='+1300')
     Traceback (most recent call last):
     ...
-    InvalidDateOffset: Invalid date offset: +1300
+    hl7apy.exceptions.InvalidDateOffset: Invalid date offset: +1300
     """
     def __init__(self, offset):
         self.offset = offset
@@ -294,7 +294,7 @@ class InvalidMicrosecondsPrecision(HL7apyException):
     >>> DTM(value='20131010', microsec_precision=5)
     Traceback (most recent call last):
     ...
-    InvalidMicrosecondsPrecision: Invalid microseconds precision. It must be between 1 and 4
+    hl7apy.exceptions.InvalidMicrosecondsPrecision: Invalid microseconds precision. It must be between 1 and 4
     """
 
     def __str__(self):
@@ -311,7 +311,7 @@ class InvalidEncodingChars(HL7apyException):
     >>> m = Message('ADT_A01', encoding_chars=encoding_chars)
     Traceback (most recent call last):
     ...
-    InvalidEncodingChars: Missing required encoding chars
+    hl7apy.exceptions.InvalidEncodingChars: <unprintable InvalidEncodingChars object>
     """
     def __str__(self):
         return self.message if self.message else 'Invalid encoding chars'

--- a/hl7apy/exceptions.py
+++ b/hl7apy/exceptions.py
@@ -20,6 +20,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 class HL7apyException(Exception):
     """
     Base exception class for hl7apy

--- a/hl7apy/factories.py
+++ b/hl7apy/factories.py
@@ -23,6 +23,13 @@
 This module contains factory functions for hl7apy base data types.
 The functions get the value of the data type as string and return the correct object
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 
 from decimal import Decimal, InvalidOperation
 from types import FunctionType

--- a/hl7apy/factories.py
+++ b/hl7apy/factories.py
@@ -97,7 +97,7 @@ def datatype_factory(datatype, value, version=None, validation_level=None):
         return factory(value, validation_level=validation_level)
     except KeyError:
         raise InvalidDataType(datatype)
-    except ValueError, e:
+    except ValueError as e:
         if Validator.is_strict(validation_level):
             raise e
         # TODO: Do we really want this? In that case the parent's datatype must be changed accordingly

--- a/hl7apy/mllp.py
+++ b/hl7apy/mllp.py
@@ -1,3 +1,6 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2012-2015, CRS4
@@ -21,7 +24,7 @@
 
 import re
 import socket
-from SocketServer import StreamRequestHandler, TCPServer, ThreadingMixIn
+from socketserver import StreamRequestHandler, TCPServer, ThreadingMixIn
 
 from hl7apy.parser import get_message_type
 from hl7apy.exceptions import HL7apyException, ParserError

--- a/hl7apy/mllp.py
+++ b/hl7apy/mllp.py
@@ -1,3 +1,8 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import range
 # -*- coding: utf-8 -*-
 #

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -54,7 +54,7 @@ def parse_message(message, validation_level=None, find_groups=True, message_prof
     :param find_groups: if ``True``, automatically assign the segments found to the appropriate
         :class:`Groups <hl7apy.core.Group>` instances. If ``False``, the segments found are assigned as
         children of the :class:`Message <hl7apy.core.Message>` instance
-        
+
     :type force_validation: ``bool``
     :type force_validation: if ``True``, automatically forces the message validation after the end of the parsing
 
@@ -63,11 +63,11 @@ def parse_message(message, validation_level=None, find_groups=True, message_prof
     >>> message = "MSH|^~\&|GHH_ADT||||20080115153000||OML^O33^OML_O33|0123456789|P|2.5||||AL\\rPID|1||" \
     "566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004|||M\\r"
     >>> m = parse_message(message)
-    >>> print m
+    >>> print(m)
     <Message OML_O33>
-    >>> print m.msh.sending_application.to_er7()
+    >>> print(m.msh.sending_application.to_er7())
     GHH_ADT
-    >>> print m.children
+    >>> print(m.children)
     [<Segment MSH>, <Group OML_O33_PATIENT>]
     """
     message = message.lstrip()
@@ -130,7 +130,7 @@ def parse_segments(text, version=None, encoding_chars=None, validation_level=Non
 
     >>> segments = "EVN||20080115153000||||20080114003000\\rPID|1||566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||" \
     "2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004|||M\\r"
-    >>> print parse_segments(segments)
+    >>> print(parse_segments(segments))
     [<Segment EVN>, <Segment PID>]
     """
     version = _get_version(version)
@@ -182,9 +182,9 @@ def parse_segment(text, version=None, encoding_chars=None, validation_level=None
 
     >>> segment = "EVN||20080115153000||||20080114003000"
     >>> s =  parse_segment(segment)
-    >>> print s
+    >>> print(s)
     <Segment EVN>
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     EVN||20080115153000||||20080114003000
     """
     version = _get_version(version)
@@ -235,16 +235,16 @@ def parse_fields(text, name_prefix=None, version=None, encoding_chars=None, vali
 
     >>> fields = "1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA"
     >>> nk1_fields = parse_fields(fields, name_prefix="NK1")
-    >>> print nk1_fields
+    >>> print(nk1_fields)
     [<Field NK1_1 (SET_ID_NK1) of type SI>, <Field NK1_2 (NAME) of type XPN>, <Field NK1_3 (RELATIONSHIP) of type CE>, \
 <Field NK1_4 (ADDRESS) of type XAD>]
     >>> s = Segment("NK1")
     >>> s.children = nk1_fields
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     NK1|1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA
     >>> unknown_fields = parse_fields(fields)
     >>> s.children = unknown_fields
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     NK1||||||||||||||||||||||||||||||||||||||||1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA
     """
     version = _get_version(version)
@@ -314,14 +314,14 @@ def parse_field(text, name=None, version=None, encoding_chars=None, validation_l
 
     >>> field = "NUCLEAR^NELDA^W"
     >>> nk1_2 = parse_field(field, name="NK1_2")
-    >>> print nk1_2
+    >>> print(nk1_2)
     <Field NK1_2 (NAME) of type XPN>
-    >>> print nk1_2.to_er7()
+    >>> print(nk1_2.to_er7())
     NUCLEAR^NELDA^W
     >>> unknown = parse_field(field)
-    >>> print unknown
+    >>> print(unknown)
     <Field of type None>
-    >>> print unknown.to_er7()
+    >>> print(unknown.to_er7())
     NUCLEAR^NELDA^W
     """
     version = _get_version(version)
@@ -384,11 +384,11 @@ def parse_components(text, field_datatype='ST', version=None, encoding_chars=Non
 
     >>> components = "NUCLEAR^NELDA^W^^TEST"
     >>> xpn = parse_components(components, field_datatype="XPN")
-    >>> print xpn
+    >>> print(xpn)
     [<Component XPN_1 (FAMILY_NAME) of type FN>, <Component XPN_2 (GIVEN_NAME) of type ST>, \
 <Component XPN_3 (SECOND_AND_FURTHER_GIVEN_NAMES_OR_INITIALS_THEREOF) of type ST>, \
 <Component XPN_5 (PREFIX_E_G_DR) of type ST>]
-    >>> print parse_components(components)
+    >>> print(parse_components(components))
     [<Component ST (None) of type ST>, <Component ST (None) of type ST>, <Component ST (None) of type ST>, \
 <Component ST (None) of type ST>, <Component ST (None) of type ST>]
     """
@@ -458,11 +458,11 @@ def parse_component(text, name=None, datatype='ST', version=None, encoding_chars
 
     >>> component = "GATEWAY&1.3.6.1.4.1.21367.2011.2.5.17"
     >>> cx_4 = parse_component(component, name="CX_4")
-    >>> print cx_4
+    >>> print(cx_4)
     <Component CX_4 (ASSIGNING_AUTHORITY) of type None>
-    >>> print cx_4.to_er7()
+    >>> print(cx_4.to_er7())
     GATEWAY&1.3.6.1.4.1.21367.2011.2.5.17
-    >>> print parse_component(component)
+    >>> print(parse_component(component))
     <Component ST (None) of type None>
     """
     version = _get_version(version)
@@ -514,17 +514,17 @@ def parse_subcomponents(text, component_datatype='ST', version=None, encoding_ch
 
     >>> subcomponents= "ID&TEST&&AHAH"
     >>> cwe = parse_subcomponents(subcomponents, component_datatype="CWE")
-    >>> print cwe
+    >>> print(cwe)
     [<SubComponent CWE_1>, <SubComponent CWE_2>, <SubComponent CWE_4>]
     >>> c = Component(datatype='CWE')
     >>> c.children = cwe
-    >>> print c.to_er7()
+    >>> print(c.to_er7())
     ID&TEST&&AHAH
     >>> subs = parse_subcomponents(subcomponents)
-    >>> print subs
+    >>> print(subs)
     [<SubComponent ST>, <SubComponent ST>, <SubComponent ST>, <SubComponent ST>]
     >>> c.children = subs
-    >>> print c.to_er7()
+    >>> print(c.to_er7())
     &&&&&&&&&ID&TEST&&AHAH
     """
     version = _get_version(version)

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -1,3 +1,4 @@
+from builtins import range
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2012-2015, CRS4
@@ -668,7 +669,7 @@ def create_groups(message, children, validation_level=None):
     # for each segment found in the message...
     for c in children:
         found = -1
-        for x in xrange(len(search_data['structures'])):
+        for x in range(len(search_data['structures'])):
             found = _find_group(c, search_data, validation_level)
             # group not found at the current level, go back to the previous level
             if found == -1:

--- a/hl7apy/utils.py
+++ b/hl7apy/utils.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import re
 from datetime import datetime
 

--- a/hl7apy/v2_2/__init__.py
+++ b/hl7apy/v2_2/__init__.py
@@ -19,13 +19,14 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_2/__init__.py
+++ b/hl7apy/v2_2/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_2/datatypes.py
+++ b/hl7apy/v2_2/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'ABSRANGE': ('sequence',
                           (('ABSRANGE_1', (0, 1)),
                            ('ABSRANGE_2', (0, 1)),

--- a/hl7apy/v2_2/fields.py
+++ b/hl7apy/v2_2/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ACC_1': ('leaf', 'TS', 'ACCIDENT_DATE_TIME', None),
           'ACC_2': ('leaf', 'ID', 'ACCIDENT_CODE', 'HL70050'),
           'ACC_3': ('leaf', 'ST', 'ACCIDENT_LOCATION', None),

--- a/hl7apy/v2_2/groups.py
+++ b/hl7apy/v2_2/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)), ('IN2', (0, 1)), ('IN3', (0, 1)))),
           'ADR_A19_QUERY_RESPONSE': ('sequence',

--- a/hl7apy/v2_2/messages.py
+++ b/hl7apy/v2_2/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence', (('MSH', (1, 1)), ('MSA', (1, 1)), ('ERR', (0, 1)))),
             'ADR_A19': ('sequence',
                         (('MSH', (1, 1)),

--- a/hl7apy/v2_2/segments.py
+++ b/hl7apy/v2_2/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ACC': ('sequence',
                     (('ACC_1', (0, 1)), ('ACC_2', (0, 1)), ('ACC_3', (0, 1)))),
             'ADD': ('sequence', (('ADD_1', (0, 1)),)),

--- a/hl7apy/v2_3/__init__.py
+++ b/hl7apy/v2_3/__init__.py
@@ -19,13 +19,14 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3/__init__.py
+++ b/hl7apy/v2_3/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_3/datatypes.py
+++ b/hl7apy/v2_3/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'ABSRANGE': ('sequence',
                           (('ABSRANGE_1', (0, 1)),
                            ('ABSRANGE_2', (0, 1)),

--- a/hl7apy/v2_3/fields.py
+++ b/hl7apy/v2_3/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ACC_1': ('leaf', 'TS', 'ACCIDENT_DATE_TIME', None),
           'ACC_2': ('leaf', 'CE', 'ACCIDENT_CODE', 'HL70050'),
           'ACC_3': ('leaf', 'ST', 'ACCIDENT_LOCATION', None),

--- a/hl7apy/v2_3/groups.py
+++ b/hl7apy/v2_3/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADT_A01_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)), ('IN2', (0, 1)), ('IN3', (0, 1)))),
           'ADT_A01_PROCEDURE': ('sequence', (('PR1', (1, 1)), ('ROL', (0, -1)))),

--- a/hl7apy/v2_3/messages.py
+++ b/hl7apy/v2_3/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence', (('MSH', (1, 1)), ('MSA', (1, 1)), ('ERR', (0, 1)))),
             'ADT_A01': ('sequence',
                         (('MSH', (1, 1)),

--- a/hl7apy/v2_3/segments.py
+++ b/hl7apy/v2_3/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ACC': ('sequence',
                     (('ACC_1', (0, 1)),
                      ('ACC_2', (0, 1)),

--- a/hl7apy/v2_3_1/__init__.py
+++ b/hl7apy/v2_3_1/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_3_1/__init__.py
+++ b/hl7apy/v2_3_1/__init__.py
@@ -19,14 +19,15 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3_1/datatypes.py
+++ b/hl7apy/v2_3_1/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'AD': ('sequence',
                     (('AD_1', (0, 1)),
                      ('AD_2', (0, 1)),

--- a/hl7apy/v2_3_1/fields.py
+++ b/hl7apy/v2_3_1/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ACC_1': ('leaf', 'TS', 'ACCIDENT_DATE_TIME', None),
           'ACC_2': ('leaf', 'CE', 'ACCIDENT_CODE', 'HL70050'),
           'ACC_3': ('leaf', 'ST', 'ACCIDENT_LOCATION', None),

--- a/hl7apy/v2_3_1/groups.py
+++ b/hl7apy/v2_3_1/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)), ('IN2', (0, 1)), ('IN3', (0, -1)))),
           'ADR_A19_PROCEDURE': ('sequence', (('PR1', (1, 1)), ('ROL', (0, -1)))),

--- a/hl7apy/v2_3_1/messages.py
+++ b/hl7apy/v2_3_1/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence', (('MSH', (1, 1)), ('MSA', (1, 1)), ('ERR', (0, 1)))),
             'ADR_A19': ('sequence',
                         (('MSH', (1, 1)),

--- a/hl7apy/v2_3_1/segments.py
+++ b/hl7apy/v2_3_1/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ACC': ('sequence',
                     (('ACC_1', (0, 1)),
                      ('ACC_2', (0, 1)),

--- a/hl7apy/v2_3_1/tables.py
+++ b/hl7apy/v2_3_1/tables.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 TABLES = {'HL70001': ('Sex',
                       (('F', 'Female'),
                        ('M', 'Male'),

--- a/hl7apy/v2_4/__init__.py
+++ b/hl7apy/v2_4/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_4/__init__.py
+++ b/hl7apy/v2_4/__init__.py
@@ -19,14 +19,15 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_4/datatypes.py
+++ b/hl7apy/v2_4/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'AD': ('sequence',
                     (('AD_1', (0, 1)),
                      ('AD_2', (0, 1)),

--- a/hl7apy/v2_4/fields.py
+++ b/hl7apy/v2_4/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ABS_1': ('leaf', 'XCN', 'DISCHARGE_CARE_PROVIDER', 'HL70010'),
           'ABS_10': ('leaf', 'ID', 'CAESARIAN_SECTION_INDICATOR', 'HL70136'),
           'ABS_11': ('leaf', 'CE', 'GESTATION_CATEGORY_CODE', 'HL70424'),

--- a/hl7apy/v2_4/groups.py
+++ b/hl7apy/v2_4/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)),
                                  ('IN2', (0, 1)),

--- a/hl7apy/v2_4/messages.py
+++ b/hl7apy/v2_4/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence', (('MSH', (1, 1)), ('MSA', (1, 1)), ('ERR', (0, 1)))),
             'ACK_N02': ('sequence', (('MSH', (1, 1)), ('MSA', (1, 1)))),
             'ADR_A19': ('sequence',

--- a/hl7apy/v2_4/segments.py
+++ b/hl7apy/v2_4/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ABS': ('sequence',
                     (('ABS_1', (0, 1)),
                      ('ABS_2', (0, 1)),

--- a/hl7apy/v2_4/tables.py
+++ b/hl7apy/v2_4/tables.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 TABLES = {'HL70001': ('Administrative sex',
                       (('A', 'Ambiguous'),
                        ('F', 'Female'),

--- a/hl7apy/v2_5/__init__.py
+++ b/hl7apy/v2_5/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_5/__init__.py
+++ b/hl7apy/v2_5/__init__.py
@@ -19,14 +19,15 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5/datatypes.py
+++ b/hl7apy/v2_5/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'AD': ('sequence',
                     (('AD_1', (0, 1)),
                      ('AD_2', (0, 1)),

--- a/hl7apy/v2_5/fields.py
+++ b/hl7apy/v2_5/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ABS_1': ('leaf', 'XCN', 'DISCHARGE_CARE_PROVIDER', 'HL70010'),
           'ABS_10': ('leaf', 'ID', 'CAESARIAN_SECTION_INDICATOR', 'HL70136'),
           'ABS_11': ('leaf', 'CE', 'GESTATION_CATEGORY_CODE', 'HL70424'),

--- a/hl7apy/v2_5/groups.py
+++ b/hl7apy/v2_5/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)),
                                  ('IN2', (0, 1)),

--- a/hl7apy/v2_5/messages.py
+++ b/hl7apy/v2_5/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence',
                     (('MSH', (1, 1)),
                      ('SFT', (0, -1)),

--- a/hl7apy/v2_5/segments.py
+++ b/hl7apy/v2_5/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ABS': ('sequence',
                     (('ABS_1', (0, 1)),
                      ('ABS_2', (0, 1)),

--- a/hl7apy/v2_5/tables.py
+++ b/hl7apy/v2_5/tables.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 TABLES = {'HL70001': ('Administrative Sex',
                       (('A', 'Ambiguous'),
                        ('F', 'Female'),

--- a/hl7apy/v2_5_1/__init__.py
+++ b/hl7apy/v2_5_1/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_5_1/__init__.py
+++ b/hl7apy/v2_5_1/__init__.py
@@ -19,14 +19,15 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5_1/datatypes.py
+++ b/hl7apy/v2_5_1/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'AD': ('sequence',
                     (('AD_1', (0, 1)),
                      ('AD_2', (0, 1)),

--- a/hl7apy/v2_5_1/fields.py
+++ b/hl7apy/v2_5_1/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ABS_1': ('leaf', 'XCN', 'DISCHARGE_CARE_PROVIDER', 'HL70010'),
           'ABS_10': ('leaf', 'ID', 'CAESARIAN_SECTION_INDICATOR', 'HL70136'),
           'ABS_11': ('leaf', 'CE', 'GESTATION_CATEGORY_CODE', 'HL70424'),

--- a/hl7apy/v2_5_1/groups.py
+++ b/hl7apy/v2_5_1/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)),
                                  ('IN2', (0, 1)),

--- a/hl7apy/v2_5_1/messages.py
+++ b/hl7apy/v2_5_1/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence',
                     (('MSH', (1, 1)),
                      ('SFT', (0, -1)),

--- a/hl7apy/v2_5_1/segments.py
+++ b/hl7apy/v2_5_1/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ABS': ('sequence',
                     (('ABS_1', (0, 1)),
                      ('ABS_2', (0, 1)),

--- a/hl7apy/v2_5_1/tables.py
+++ b/hl7apy/v2_5_1/tables.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 TABLES = {'HL70001': ('Administrative Sex',
                       (('A', 'Ambiguous'),
                        ('F', 'Female'),

--- a/hl7apy/v2_6/__init__.py
+++ b/hl7apy/v2_6/__init__.py
@@ -19,14 +19,15 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.v2_6.base_datatypes import ST as _ST26
 from hl7apy.exceptions import ChildNotFound

--- a/hl7apy/v2_6/__init__.py
+++ b/hl7apy/v2_6/__init__.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 
 from .messages import MESSAGES

--- a/hl7apy/v2_6/base_datatypes.py
+++ b/hl7apy/v2_6/base_datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from hl7apy.base_datatypes import TextualDataType
 
 

--- a/hl7apy/v2_6/datatypes.py
+++ b/hl7apy/v2_6/datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 DATATYPES = {'AD': ('sequence',
                     (('AD_1', (0, 1)),
                      ('AD_2', (0, 1)),

--- a/hl7apy/v2_6/fields.py
+++ b/hl7apy/v2_6/fields.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 FIELDS = {'ABS_1': ('leaf', 'XCN', 'DISCHARGE_CARE_PROVIDER', 'HL70010'),
           'ABS_10': ('leaf', 'ID', 'CAESARIAN_SECTION_INDICATOR', 'HL70136'),
           'ABS_11': ('leaf', 'CWE', 'GESTATION_CATEGORY_CODE', 'HL70424'),

--- a/hl7apy/v2_6/groups.py
+++ b/hl7apy/v2_6/groups.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 GROUPS = {'ADR_A19_INSURANCE': ('sequence',
                                 (('IN1', (1, 1)),
                                  ('IN2', (0, 1)),

--- a/hl7apy/v2_6/messages.py
+++ b/hl7apy/v2_6/messages.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 MESSAGES = {'ACK': ('sequence',
                     (('MSH', (1, 1)),
                      ('SFT', (0, -1)),

--- a/hl7apy/v2_6/segments.py
+++ b/hl7apy/v2_6/segments.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 SEGMENTS = {'ABS': ('sequence',
                     (('ABS_1', (0, 1)),
                      ('ABS_2', (0, 1)),

--- a/hl7apy/v2_6/tables.py
+++ b/hl7apy/v2_6/tables.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 TABLES = {'HL70001': ('Administrative Sex',
                       (('A', 'Ambiguous'),
                        ('F', 'Female'),

--- a/hl7apy/validation.py
+++ b/hl7apy/validation.py
@@ -1,3 +1,4 @@
+from builtins import object
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2012-2015, CRS4

--- a/hl7apy/validation.py
+++ b/hl7apy/validation.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import object
 # -*- coding: utf-8 -*-
 #

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,13 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from distutils.core import setup
 from distutils.errors import DistutilsSetupError
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,7 +287,7 @@ class TestMessage(unittest.TestCase):
         b.value = msg
         parsed_b = parse_message(msg, validation_level=VALIDATION_LEVEL.STRICT)
         self.assertEqual(b.to_er7(), parsed_b.to_er7())
-        self.assertEqual(b.children.indexes.keys(), parsed_b.children.indexes.keys())
+        self.assertEqual(list(b.children.indexes.keys()), list(parsed_b.children.indexes.keys()))
 
         c = Message('ADT_A01', validation_level=VALIDATION_LEVEL.TOLERANT)
         with self.assertRaises(OperationNotAllowed):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import unittest
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import unittest
 
 from datetime import datetime

--- a/tests/test_mllp.py
+++ b/tests/test_mllp.py
@@ -1,3 +1,5 @@
+from future import standard_library
+standard_library.install_aliases()
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2012-2015, CRS4

--- a/tests/test_mllp.py
+++ b/tests/test_mllp.py
@@ -1,3 +1,8 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *
 from future import standard_library
 standard_library.install_aliases()
 # -*- coding: utf-8 -*-
@@ -119,10 +124,10 @@ class TestMLLPWithErrorHandler(unittest.TestCase):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((HOST, PORT))
-            sock.sendall(msg)
+            sock.sendall(msg.encode('ascii'))
             res = []
             while True:
-                received = sock.recv(1)
+                received = sock.recv(1).decode('ascii')
                 if not received:
                     break
                 res.append(received)
@@ -175,7 +180,7 @@ class TestMLLPWithoutErrorHandler(unittest.TestCase):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((HOST, PORT + 1))
-            sock.sendall(msg)
+            sock.sendall(msg.encode('ascii'))
             res = []
             while True:
                 received = sock.recv(1)

--- a/tests/test_mllp.py
+++ b/tests/test_mllp.py
@@ -127,10 +127,10 @@ class TestMLLPWithErrorHandler(unittest.TestCase):
             sock.sendall(msg.encode('ascii'))
             res = []
             while True:
-                received = sock.recv(1).decode('ascii')
+                received = sock.recv(1)
                 if not received:
                     break
-                res.append(received)
+                res.append(received.decode('ascii'))
         finally:
             sock.close()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import unittest
 

--- a/tests/test_to_string.py
+++ b/tests/test_to_string.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import unittest
 from hl7apy.core import Message, Group, Segment, Field, Component, SubComponent
 from hl7apy.parser import parse_segment, parse_message

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,6 +19,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import unittest
 

--- a/utils/hl7apy_profile_parser
+++ b/utils/hl7apy_profile_parser
@@ -130,7 +130,7 @@ class ProfileParser(object):
             if not os.path.exists(self.output_path):
                 os.mkdir(self.output_path)
         except Exception, ex:
-            print "Error occurred while saving the output to: ", self.output_path, ex
+            print("Error occurred while saving the output to: ", self.output_path, ex)
             sys.exit(1)
 
         if os.path.isdir(self.input_path):
@@ -158,13 +158,13 @@ class ProfileParser(object):
             with open(schema_path) as xml_file:
                 data = xml_file.read()
         except Exception, ex:
-            print "Error occurred while opening the message profile file: ", ex
+            print("Error occurred while opening the message profile file: ", ex)
             sys.exit(1)
 
         try:
             f = objectify.XML(data)
         except Exception, ex:
-            print "Invalid XML file: ", profile_file, ex
+            print("Invalid XML file: ", profile_file, ex)
             sys.exit(1)
 
         message_structure = f.HL7v2xStaticDef.get('MsgStructID')

--- a/utils/test_parsing_message.py
+++ b/utils/test_parsing_message.py
@@ -93,7 +93,7 @@ def print_report(n_messages, msg_per_version, msg_per_type, exceptions,
                 output.write("{0}: {1}\n".format(version, msg_per_version[vl][version]))
 
             output.write("\n\nMessage types details:\n\n")
-            for k, v in msg_per_type[vl].items():
+            for k, v in list(msg_per_type[vl].items()):
                 output.write("{0}: {1}\n".format(k, v))
 
             output.write("\n\nProblems occurred:\n\n")

--- a/utils/test_parsing_message.py
+++ b/utils/test_parsing_message.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import re
 import sys

--- a/utils/test_parsing_message.py
+++ b/utils/test_parsing_message.py
@@ -19,6 +19,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import os
 import re
 import sys

--- a/utils/xsd_parser.py
+++ b/utils/xsd_parser.py
@@ -20,6 +20,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from builtins import object
 import sys
 import os
 import re
@@ -65,7 +66,7 @@ class XSDParser(object):
         parse_res = self.parse_schema("datatypes.xsd")
         content, types = parse_res[0], parse_res[2]
         content.update(types)
-        content = {k: v for k, v in content.iteritems() if not k.endswith("_CONTENT")}
+        content = {k: v for k, v in content.items() if not k.endswith("_CONTENT")}
         self.generate_module("datatypes.py", content)
 
     def parse_messages(self):
@@ -82,7 +83,7 @@ class XSDParser(object):
             message, ext = os.path.splitext(f)
             content = self.parse_schema(f)[0]
             message_def[message] = content[message.upper()]
-            groups.update(g for g in content.iteritems() if g[0] != message)
+            groups.update(g for g in content.items() if g[0] != message)
         self.generate_module("messages.py", message_def)
         self.generate_module("groups.py", groups)
 
@@ -132,7 +133,7 @@ class XSDParser(object):
 
     def reduce_content_size(self, content):
         to_delete = []
-        for key, value in content.iteritems():
+        for key, value in content.items():
             if value is not None:
                 if value['type'] in ('sequence', 'choice') and value.get('content'):
                     try:

--- a/utils/xsd_parser.py
+++ b/utils/xsd_parser.py
@@ -20,6 +20,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from builtins import object
 import sys
 import os
@@ -66,7 +72,7 @@ class XSDParser(object):
         parse_res = self.parse_schema("datatypes.xsd")
         content, types = parse_res[0], parse_res[2]
         content.update(types)
-        content = {k: v for k, v in content.items() if not k.endswith("_CONTENT")}
+        content = {k: v for k, v in list(content.items()) if not k.endswith("_CONTENT")}
         self.generate_module("datatypes.py", content)
 
     def parse_messages(self):
@@ -83,7 +89,7 @@ class XSDParser(object):
             message, ext = os.path.splitext(f)
             content = self.parse_schema(f)[0]
             message_def[message] = content[message.upper()]
-            groups.update(g for g in content.items() if g[0] != message)
+            groups.update(g for g in list(content.items()) if g[0] != message)
         self.generate_module("messages.py", message_def)
         self.generate_module("groups.py", groups)
 
@@ -133,7 +139,7 @@ class XSDParser(object):
 
     def reduce_content_size(self, content):
         to_delete = []
-        for key, value in content.items():
+        for key, value in list(content.items()):
             if value is not None:
                 if value['type'] in ('sequence', 'choice') and value.get('content'):
                     try:

--- a/utils/xsd_parser.py
+++ b/utils/xsd_parser.py
@@ -19,6 +19,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
 import os
 import re
@@ -34,8 +35,8 @@ class XSDParser(object):
         self.output_path = output_path
         try:
             methods = [getattr(self, p) for p in to_parse]
-        except Exception, ex:
-            print "Invalid parsing options.", ex
+        except Exception as ex:
+            print("Invalid parsing options.", ex)
             sys.exit(1)
         for m in methods:
             m()
@@ -95,14 +96,14 @@ class XSDParser(object):
             schema_path = os.path.join(self.input_path, schema_file)
             with open(schema_path) as xml_file:
                 data = xml_file.read()
-        except Exception, ex:
-            print "Error occurred while opening the XSD file: ", ex
+        except Exception as ex:
+            print("Error occurred while opening the XSD file: ", ex)
             sys.exit(1)
 
         try:
             f = objectify.XML(data)
-        except Exception, ex:
-            print "Invalid XSD file: ", schema_file, ex
+        except Exception as ex:
+            print("Invalid XSD file: ", schema_file, ex)
             sys.exit(1)
 
         try:
@@ -112,7 +113,7 @@ class XSDParser(object):
 
         try:
             types = [Node(c).to_dict() for c in f.complexType]
-        except Exception, ex:
+        except Exception as ex:
             complex_types = {}  # no xsd:complexType found,
         else:
             complex_types = dict((node.get('name'), node.get('content')) for node in types)
@@ -125,7 +126,7 @@ class XSDParser(object):
                     if content.get('type') == 'annotation':
                         content = node['content']
                 elements[node.get('name')] = content
-        except Exception, ex:
+        except Exception as ex:
             elements = {}  # no xsd:element found
         return elements, includes, complex_types
 
@@ -163,8 +164,8 @@ class XSDParser(object):
             with open(module_path, "w") as output_file:
                 output_file.write("{0} = ".format(constant_name.upper()))
                 pprint.pprint(module_content, output_file)
-        except Exception, ex:
-            print "Error occurred while saving the output to: ", module_name, ex
+        except Exception as ex:
+            print("Error occurred while saving the output to: ", module_name, ex)
             sys.exit(1)
 
 


### PR DESCRIPTION
This gives compatibility to python 2.7 and python 3.x (at least 3.4.3, I could test more).  Depends on future and six modules but I don't think that's too much of a sacrifice.

The mllp tests aren't working but one is a Port in Use (py27) and the other is Connection Reset by Peer (py3) so it might be my system, I'll fiddle with it more later.

Thanks,