### PR TITLE
Updated to work with Python 3.

### DIFF
--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -23,7 +23,10 @@ import os
 import sys
 import collections
 import importlib
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 from hl7apy.exceptions import UnsupportedVersion, InvalidEncodingChars, UnknownValidationLevel
 from hl7apy.consts import DEFAULT_ENCODING_CHARS, DEFAULT_VERSION, VALIDATION_LEVEL
@@ -308,7 +311,7 @@ def find_reference(name, element_types, version):
 
 def load_message_profile(path):
     with open(path) as f:
-        mp = cPickle.load(f)
+        mp = pickle.load(f)
 
     return mp
 

--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -29,6 +29,16 @@ import datetime
 from itertools import takewhile
 import importlib
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
+try:
+    xrange
+except NameError:
+    xrange = range
+
 from hl7apy import get_default_version, get_default_encoding_chars, \
     get_default_validation_level, check_validation_level, \
     check_encoding_chars, check_version, load_library, \
@@ -806,7 +816,7 @@ class Element(object):
     def _find_structure(self, reference=None):
         if self.name is not None:
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.iteritems():
+            for k, v in structure.items():
                 setattr(self, k, v)
 
     def _is_valid_child(self, child):
@@ -903,7 +913,7 @@ class SupportComplexDataType(Element):
                 datatype not in ('varies', None, self.datatype):
             reference = load_reference(datatype, 'Component', self.version)
             structure = ElementFinder.get_structure(self, reference)
-            for k, v in structure.iteritems():
+            for k, v in structure.items():
                 setattr(self, k, v)
 
         if hasattr(self, 'children') and len(self.children) >= 1:

--- a/hl7apy/factories.py
+++ b/hl7apy/factories.py
@@ -97,7 +97,7 @@ def datatype_factory(datatype, value, version=None, validation_level=None):
         return factory(value, validation_level=validation_level)
     except KeyError:
         raise InvalidDataType(datatype)
-    except ValueError, e:
+    except ValueError as e:
         if Validator.is_strict(validation_level):
             raise e
         # TODO: Do we really want this? In that case the parent's datatype must be changed accordingly

--- a/hl7apy/mllp.py
+++ b/hl7apy/mllp.py
@@ -21,7 +21,10 @@
 
 import re
 import socket
-from SocketServer import StreamRequestHandler, TCPServer, ThreadingMixIn
+try:
+    from SocketServer import StreamRequestHandler, TCPServer, ThreadingMixIn
+except ImportError:
+    from socketserver import StreamRequestHandler, TCPServer, ThreadingMixIn
 
 from hl7apy.parser import get_message_type
 from hl7apy.exceptions import HL7apyException, ParserError

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -21,6 +21,11 @@
 
 import re
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 from hl7apy import get_default_encoding_chars, get_default_version, \
     get_default_validation_level, check_version, check_encoding_chars, check_validation_level
 from hl7apy.consts import N_SEPS

--- a/hl7apy/v2_2/__init__.py
+++ b/hl7apy/v2_2/__init__.py
@@ -21,11 +21,19 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3/__init__.py
+++ b/hl7apy/v2_3/__init__.py
@@ -21,11 +21,18 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3_1/__init__.py
+++ b/hl7apy/v2_3_1/__init__.py
@@ -21,12 +21,20 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+    from tables import TABLES
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+    from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_4/__init__.py
+++ b/hl7apy/v2_4/__init__.py
@@ -21,12 +21,20 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+    from tables import TABLES
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+    from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5/__init__.py
+++ b/hl7apy/v2_5/__init__.py
@@ -21,12 +21,20 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+    from tables import TABLES
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+    from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5_1/__init__.py
+++ b/hl7apy/v2_5_1/__init__.py
@@ -21,12 +21,20 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+    from tables import TABLES
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+    from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_6/__init__.py
+++ b/hl7apy/v2_6/__init__.py
@@ -21,12 +21,20 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+try:
+    from messages import MESSAGES
+    from segments import SEGMENTS
+    from fields import FIELDS
+    from datatypes import DATATYPES
+    from groups import GROUPS
+    from tables import TABLES
+except ImportError:
+    from .messages import MESSAGES
+    from .segments import SEGMENTS
+    from .fields import FIELDS
+    from .datatypes import DATATYPES
+    from .groups import GROUPS
+    from .tables import TABLES
 
 from hl7apy.v2_6.base_datatypes import ST as _ST26
 from hl7apy.exceptions import ChildNotFound


### PR DESCRIPTION
This pull request adds support for python 3.  I chose to use the try/except approach rather than adding any external dependencies like six or python-future.  I also leveraged the added support for unicode literals in python 3.3 (which substantially reduced the amount of code that needed to be altered).  As a result, it works on python 3.3+.
