### PR TITLE
Updated code for Python 3 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 before_install:
   pip install coveralls
 # command to install dependencies

--- a/examples/lab62/actor.py
+++ b/examples/lab62/actor.py
@@ -19,6 +19,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import uuid
 
 from hl7apy.core import Message, Segment
@@ -45,17 +46,17 @@ class LB(object):
     @staticmethod
     def receive(message):
         # print to stdout the data received
-        print "Received by LB"
+        print("Received by LB")
         try:
             # parse the incoming HL7 message
             m = parse_message(message, find_groups=False)
         except:
-            print 'parsing failed', repr(message)
+            print('parsing failed', repr(message), sep=' ')
         else:
-            print "Message type:", m.MSH.message_type.to_er7()
-            print "Message content:", repr(m.to_er7())
+            print("Message type:", m.MSH.message_type.to_er7(), sep=' ')
+            print("Message content:", repr(m.to_er7()), sep=' ')
             surname, name = m.PID.PID_5.family_name.to_er7(), m.PID.PID_5.given_name.to_er7()
-            print "Patient data:", surname, name
+            print("Patient data:", surname, name, sep=' ')
 
 class LIP(object):
     """
@@ -85,17 +86,17 @@ class LIP(object):
         :param message: incoming message
         :return: response encoded to ER7 - it can be a NAK or RSP_K11 message
         """
-        print "Received by LIP", repr(message)
+        print("Received by LIP", repr(message), sep=' ')
 
         try:
             # parse the incoming message
             m = parse_message(message, find_groups=False)
         except:
-            print 'parsing failed', repr(message)
+            print('parsing failed', repr(message), sep=' ')
             response = LIP.nak()
         else:
-            print "Message type:", m.MSH.message_type.to_er7()
-            print "Message content:", repr(m.to_er7())
+            print("Message type:", m.MSH.message_type.to_er7(), sep=' ')
+            print("Message content:", repr(m.to_er7()), sep=' ')
             if m.MSH.MSH_9.MSH_9_3.to_er7() == 'QBP_Q11':
                 # create a new RSP_K11 message
                 response = Message("RSP_K11")

--- a/examples/lab62/server.py
+++ b/examples/lab62/server.py
@@ -19,8 +19,12 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import SocketServer
 import re
+
+try:
+    import SocketServer as socketserver
+except ImportError:
+    import socketserver
 
 from actor import LIP
 
@@ -47,7 +51,7 @@ class MLLProtocol(object):
             message = matched.groups()[0]
         return message
 
-class MLLPServer(SocketServer.StreamRequestHandler):
+class MLLPServer(socketserver.StreamRequestHandler):
     """
     Simplistic implementation of a TCP server implementing the MLLP protocol
 
@@ -59,7 +63,7 @@ class MLLPServer(SocketServer.StreamRequestHandler):
         while True:
             char = self.rfile.read(1)
             if not char:
-                print 'client disconnected'
+                print('client disconnected')
                 break
             line += char
             # check if incoming buffer contains a HL7 message
@@ -74,5 +78,5 @@ class MLLPServer(SocketServer.StreamRequestHandler):
 if __name__ == "__main__":
     HOST, PORT = "localhost", 6000
 
-    server = SocketServer.TCPServer((HOST, PORT), MLLPServer)
+    server = socketserver.TCPServer((HOST, PORT), MLLPServer)
     server.serve_forever()

--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -19,11 +19,16 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import os
 import sys
 import collections
 import importlib
-import cPickle
+
+if sys.version_info[0] <= 2:
+    import cPickle as pickle
+else:
+    import pickle
 
 from hl7apy.exceptions import UnsupportedVersion, InvalidEncodingChars, UnknownValidationLevel
 from hl7apy.consts import DEFAULT_ENCODING_CHARS, DEFAULT_VERSION, VALIDATION_LEVEL
@@ -89,7 +94,7 @@ def get_default_encoding_chars():
     :rtype: ``dict``
     :returns: the encoding chars (see :func:`hl7apy.set_default_encoding_chars`)
 
-    >>> print get_default_encoding_chars()['FIELD']
+    >>> print(get_default_encoding_chars()['FIELD'])
     |
     """
     return _DEFAULT_ENCODING_CHARS
@@ -102,7 +107,7 @@ def get_default_version():
     :rtype: ``str``
     :returns: the default version
 
-    >>> print get_default_version()
+    >>> print(get_default_version())
     2.5
     """
     return _DEFAULT_VERSION
@@ -115,7 +120,7 @@ def get_default_validation_level():
     :rtype: ``str``
     :returns: the default validation level
 
-    >>> print get_default_validation_level()
+    >>> print(get_default_validation_level())
     2
     """
     return _DEFAULT_VALIDATION_LEVEL
@@ -129,12 +134,14 @@ def set_default_validation_level(validation_level):
     :param validation_level: validation level (see :class:`hl7apy.consts.VALIDATION_LEVEL`)
     :raises: :exc:`hl7apy.exceptions.UnknownValidationLevel` if the given validation level is unsupported
 
-    >>> set_default_validation_level(3)
-    Traceback (most recent call last):
-        ...
-    UnknownValidationLevel
+    >>> from hl7apy.exceptions import UnknownValidationLevel
+    >>> try:
+    ...     set_default_validation_level(3)
+    ...     raise AssertionError('UnknownValidationLevel exception was not raised')
+    ... except UnknownValidationLevel as ex:
+    ...     pass
     >>> set_default_validation_level(VALIDATION_LEVEL.TOLERANT)
-    >>> print get_default_validation_level()
+    >>> print(get_default_validation_level())
     2
     """
     check_validation_level(validation_level)
@@ -152,12 +159,15 @@ def set_default_version(version):
     :param version: the new default version (e.g. ``2.6``)
     :raises: :class:`hl7apy.exceptions.UnsupportedVersion` if the given version is unsupported
 
-    >>> set_default_version('22')
-    Traceback (most recent call last):
-        ...
-    UnsupportedVersion: The version 22 is not supported
+    >>> from hl7apy.exceptions import UnsupportedVersion
+    >>> try:
+    ...     set_default_version('22')
+    ...     raise AssertionError('UnsupportedVersion exception was not raised')
+    ... except UnsupportedVersion as ex:
+    ...     print(ex)
+    The version 22 is not supported
     >>> set_default_version('2.3')
-    >>> print get_default_version()
+    >>> print(get_default_version())
     2.3
     """
     check_version(version)
@@ -195,13 +205,16 @@ def set_default_encoding_chars(encoding_chars):
     |ESCAPE        |``\\``            |
     +--------------+-----------------+
 
-    >>> set_default_encoding_chars({'FIELD': '!'})
-    Traceback (most recent call last):
-        ...
-    InvalidEncodingChars: Missing required encoding chars
+    >>> from hl7apy.exceptions import InvalidEncodingChars
+    >>> try:
+    ...     set_default_encoding_chars({'FIELD': '!'})
+    ...     raise AssertionError('InvalidEncodingChars exception was not raised')
+    ... except InvalidEncodingChars as ex:
+    ...     print(ex)
+    Missing required encoding chars
     >>> set_default_encoding_chars({'FIELD': '!', 'COMPONENT': 'C', 'SUBCOMPONENT': 'S', \
                                     'REPETITION': 'R', 'ESCAPE': '\\\\'})
-    >>> print get_default_encoding_chars()['FIELD']
+    >>> print(get_default_encoding_chars()['FIELD'])
     !
     """
     check_encoding_chars(encoding_chars)
@@ -258,15 +271,18 @@ def load_reference(name, element_type, version):
     |              |('sequence', (<child>, (<min>, <max>), ...))|
     +--------------+--------------------------------------------+
 
-    >>> load_reference('UNKNOWN', 'Segment', '2.5')
-    Traceback (most recent call last):
-    ...
-    ChildNotFound: No child named UNKNOWN
+    >>> from hl7apy.exceptions import ChildNotFound
+    >>> try:
+    ...     load_reference('UNKNOWN', 'Segment', '2.5')
+    ...     raise AssertionError('ChildNotFound exception was not raised')
+    ... except ChildNotFound as ex:
+    ...     print(ex)
+    No child named UNKNOWN
     >>> r = load_reference('ADT_A01', 'Message', '2.5')
-    >>> print r[0]
+    >>> print(r[0])
     sequence
     >>> r = load_reference('MSH_3', 'Field', '2.5')
-    >>> print r[0]
+    >>> print(r[0])
     leaf
     """
     lib = load_library(version)
@@ -280,8 +296,8 @@ def find_reference(name, element_types, version):
 
     :type name: ``str``
     :param name: the element name to look for (e.g. 'MSH')
-    :type types: ``list`` or ``tuple``
-    :param types: the element classes where to look for the element (e.g. (Group, Segment))
+    :type element_types: ``list`` or ``tuple``
+    :param element_types: the element classes where to look for the element (e.g. (Group, Segment))
     :type version: ``str``
     :param version: the version of the library where to search the element (e.g. '2.6')
     :rtype: ``dict``
@@ -289,16 +305,21 @@ def find_reference(name, element_types, version):
     :raise: :class:`hl7apy.exceptions.ChildNotFound` if the element has not been found
 
     >>> from hl7apy.core import Message, Segment
-    >>> find_reference('UNKNOWN', (Segment, ), '2.5')
-    Traceback (most recent call last):
-    ...
-    ChildNotFound: No child named UNKNOWN
-    >>> find_reference('ADT_A01', (Segment,),  '2.5')
-    Traceback (most recent call last):
-    ...
-    ChildNotFound: No child named ADT_A01
+    >>> from hl7apy.exceptions import ChildNotFound
+    >>> try:
+    ...     find_reference('UNKNOWN', (Segment, ), '2.5')
+    ...     raise AssertionError('ChildNotFound exception was not raised')
+    ... except ChildNotFound as ex:
+    ...     print(ex)
+    No child named UNKNOWN
+    >>> try:
+    ...     find_reference('ADT_A01', (Segment,),  '2.5')
+    ...     raise AssertionError('ChildNotFound exception was not raised')
+    ... except ChildNotFound as ex:
+    ...     print(ex)
+    No child named ADT_A01
     >>> r = find_reference('ADT_A01', (Message,),  '2.5')
-    >>> print r['name'], r['cls']
+    >>> print(r['name'], r['cls'], sep=' ')
     ADT_A01 <class 'hl7apy.core.Message'>
     """
     lib = load_library(version)
@@ -307,8 +328,8 @@ def find_reference(name, element_types, version):
 
 
 def load_message_profile(path):
-    with open(path) as f:
-        mp = cPickle.load(f)
+    with open(path, 'rb') as f:
+        mp = pickle.load(f)
 
     return mp
 

--- a/hl7apy/base_datatypes.py
+++ b/hl7apy/base_datatypes.py
@@ -36,6 +36,7 @@ import re
 import numbers
 from datetime import datetime
 from decimal import Decimal
+from functools import cmp_to_key
 
 from hl7apy import get_default_encoding_chars, get_default_validation_level
 from hl7apy.exceptions import MaxLengthReached, InvalidHighlightRange, InvalidDateFormat, \
@@ -145,7 +146,7 @@ class TextualDataType(BaseDataType):
                 else:
                     raise InvalidHighlightRange(x, y)
 
-            self.highlights = sorted(self.highlights, cmp=_sort_highlights)
+            self.highlights = sorted(self.highlights, key=cmp_to_key(_sort_highlights))
             words = list(value)
             offset = 0
             for hl in self.highlights:

--- a/hl7apy/exceptions.py
+++ b/hl7apy/exceptions.py
@@ -31,10 +31,13 @@ class ParserError(HL7apyException):
     Error during parsing
 
     >>> from hl7apy.parser import parse_message
-    >>> m = parse_message('NOTHL7')
-    Traceback (most recent call last):
-    ...
-    ParserError: Invalid message
+    >>> from hl7apy.exceptions import ParserError
+    >>> try:
+    ...     m = parse_message('NOTHL7')
+    ...     raise AssertionError('ParserError exception was not raised')
+    ... except ParserError as ex:
+    ...     print(ex)
+    Invalid message
     """
 
 
@@ -44,16 +47,19 @@ class ValidationError(HL7apyException):
 
     >>> from hl7apy.parser import parse_message
     >>> from hl7apy.validation import VALIDATION_LEVEL
+    >>> from hl7apy.exceptions import ValidationError
     >>> msh = 'MSH|^~\&|SENDING APP|SENDING FAC|REC APP|REC FAC|20080115153000||ADT^A01^ADT_A01|' \
     '0123456789|P|2.5||||AL\\r'
     >>> evn = 'EVN||20080115153000||AAA|AAA|20080114003000\\r'
     >>> pid = 'PID|1||123-456-789^^^HOSPITAL^MR||SURNAME^NAME^A|||M|||1111 SOMEWHERE STREET^^SOMEWHERE^^^USA||' \
     '555-555-2004~444-333-222|||M\\r'
     >>> message = msh + evn + pid
-    >>> parse_message(message, validation_level=VALIDATION_LEVEL.STRICT, force_validation=True)
-    Traceback (most recent call last):
-    ...
-    ValidationError: Missing required child ADT_A01.PV1
+    >>> try:
+    ...     parse_message(message, validation_level=VALIDATION_LEVEL.STRICT, force_validation=True)
+    ...     raise AssertionError('ValidationError exception was not raised')
+    ... except ValidationError as ex:
+    ...     print(ex)
+    Missing required child ADT_A01.PV1
     """
 
 
@@ -68,10 +74,13 @@ class UnsupportedVersion(HL7apyException):
     Given version is not supported
 
     >>> from hl7apy import set_default_version
-    >>> set_default_version("2.0")
-    Traceback (most recent call last):
-    ...
-    UnsupportedVersion: The version 2.0 is not supported
+    >>> from hl7apy.exceptions import UnsupportedVersion
+    >>> try:
+    ...     set_default_version("2.0")
+    ...     raise AssertionError('UnsupportedVersion exception was not raised')
+    ... except UnsupportedVersion as ex:
+    ...     print(ex)
+    The version 2.0 is not supported
     """
     def __init__(self, version):
         self.version = version
@@ -85,11 +94,14 @@ class ChildNotFound(HL7apyException):
     Raised when a child element is not found in the HL7 reference structures for the given version
 
     >>> from hl7apy.core import Segment, Field
+    >>> from hl7apy.exceptions import ChildNotFound
     >>> s = Segment('MSH')
-    >>> s.unknown = Field()
-    Traceback (most recent call last):
-    ...
-    ChildNotFound: No child named UNKNOWN
+    >>> try:
+    ...     s.unknown = Field()
+    ...     raise AssertionError('ChildNotFound exception was not raised')
+    ... except ChildNotFound as ex:
+    ...     print(ex)
+    No child named UNKNOWN
     """
     def __init__(self, name):
         self.name = name
@@ -103,11 +115,14 @@ class ChildNotValid(HL7apyException):
     Raised when you try to assign an unexpected child to an :class:`Element <hl7apy.core.Element>`
 
     >>> from hl7apy.core import Segment, Field
+    >>> from hl7apy.exceptions import ChildNotValid
     >>> s = Segment('PID', validation_level=1)
-    >>> s.pid_1 = Field('PID_34')
-    Traceback (most recent call last):
-    ...
-    ChildNotValid: <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
+    >>> try:
+    ...     s.pid_1 = Field('PID_34')
+    ...     raise AssertionError('ChildNotValid exception was not raised')
+    ... except ChildNotValid as ex:
+    ...     print(ex)
+    <Field PID_34 (LAST_UPDATE_FACILITY) of type HD> is not a valid child for PID_1
     """
     def __init__(self, child, parent):
         self.child = child
@@ -124,10 +139,12 @@ class UnknownValidationLevel(HL7apyException):
     It should be one of those defined in :class:`VALIDATION_LEVEL <hl7apy.consts.VALIDATION_LEVEL>`.
 
     >>> from hl7apy import set_default_validation_level
-    >>> set_default_validation_level(3)
-    Traceback (most recent call last):
-    ...
-    UnknownValidationLevel
+    >>> from hl7apy.exceptions import UnknownValidationLevel
+    >>> try:
+    ...     set_default_validation_level(3)
+    ...     raise AssertionError('UnknownValidationLevel exception was not raised')
+    ... except UnknownValidationLevel as ex:
+    ...     pass
     """
 
 
@@ -136,10 +153,13 @@ class OperationNotAllowed(HL7apyException):
     Generic exception raised when something is not allowed
 
     >>> from hl7apy.core import Segment
-    >>> s = Segment()
-    Traceback (most recent call last):
-    ...
-    OperationNotAllowed: Cannot instantiate an unknown Segment
+    >>> from hl7apy.exceptions import OperationNotAllowed
+    >>> try:
+    ...     s = Segment()
+    ...     raise AssertionError('OperationNotAllowed exception was not raised')
+    ... except OperationNotAllowed as ex:
+    ...     print(ex)
+    Cannot instantiate an unknown Segment
     """
 
 
@@ -151,11 +171,14 @@ class MaxChildLimitReached(HL7apyException):
     at most 1 MSH segment)
 
     >>> from hl7apy.core import Message, Segment
+    >>> from hl7apy.exceptions import MaxChildLimitReached
     >>> m = Message("OML_O33", validation_level=1)
-    >>> m.add(Segment('MSH'))
-    Traceback (most recent call last):
-    ...
-    MaxChildLimitReached: Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
+    >>> try:
+    ...     m.add(Segment('MSH'))
+    ...     raise AssertionError('MaxChildLimitReached exception was not raised')
+    ... except MaxChildLimitReached as ex:
+    ...     print(ex)
+    Cannot add <Segment MSH>: max limit (1) reached for <Message OML_O33>
     """
     def __init__(self, parent, child, limit):
         self.parent = parent
@@ -172,11 +195,14 @@ class MaxLengthReached(HL7apyException):
 
     >>> from hl7apy.v2_5 import get_base_datatypes
     >>> from hl7apy.consts import VALIDATION_LEVEL
+    >>> from hl7apy.exceptions import MaxLengthReached
     >>> SI = get_base_datatypes()['SI']
-    >>> st = SI(value=11111, validation_level=VALIDATION_LEVEL.STRICT)
-    Traceback (most recent call last):
-    ...
-    MaxLengthReached: The value 11111 exceed the max length: 4
+    >>> try:
+    ...     st = SI(value=11111, validation_level=VALIDATION_LEVEL.STRICT)
+    ...     raise AssertionError('MaxLengthReached exception was not raised')
+    ... except MaxLengthReached as ex:
+    ...     print(ex)
+    The value 11111 exceed the max length: 4
     """
     def __init__(self, value, limit):
         self.value = value
@@ -191,10 +217,13 @@ class InvalidName(HL7apyException):
     Raised if the reference for the given class/name has not been found
 
     >>> from hl7apy.core import Message
-    >>> Message('Unknown')
-    Traceback (most recent call last):
-    ...
-    InvalidName: Invalid name for Message: UNKNOWN
+    >>> from hl7apy.exceptions import InvalidName
+    >>> try:
+    ...     Message('Unknown')
+    ...     raise AssertionError('InvalidName exception was not raised')
+    ... except InvalidName as ex:
+    ...     print(ex)
+    Invalid name for Message: UNKNOWN
     """
     def __init__(self, cls, name):
         self.cls = cls
@@ -209,12 +238,15 @@ class InvalidDataType(HL7apyException):
     Raised when the currently used HL7 version does not support the given datatype
 
     >>> from hl7apy.factories import datatype_factory
+    >>> from hl7apy.exceptions import InvalidDataType
     >>> datatype_factory('TN', '11 123456', version="2.3") #doctest: +ELLIPSIS
     <hl7apy.base_datatypes.TN object at 0x...>
-    >>> datatype_factory('TN', '11 123456', version="2.5")
-    Traceback (most recent call last):
-    ...
-    InvalidDataType: The datatype TN is not available for the given HL7 version
+    >>> try:
+    ...     datatype_factory('TN', '11 123456', version="2.5")
+    ...     raise AssertionError('InvalidDataType exception was not raised')
+    ... except InvalidDataType as ex:
+    ...     print(ex)
+    The datatype TN is not available for the given HL7 version
     """
     def __init__(self, datatype):
         self.datatype = datatype
@@ -230,11 +262,14 @@ class InvalidHighlightRange(HL7apyException):
     For a description of highlight range see :class:`hl7apy.base_datatypes.TextualDataType`
 
     >>> from hl7apy.v2_5 import ST
+    >>> from hl7apy.exceptions import InvalidHighlightRange
     >>> s = ST(value='some useful information', highlights=((5, 3),))
-    >>> s.to_er7()
-    Traceback (most recent call last):
-    ...
-    InvalidHighlightRange: Invalid highlight range: 5 - 3
+    >>> try:
+    ...     s.to_er7()
+    ...     raise AssertionError('InvalidHighlightRange exception was not raised')
+    ... except InvalidHighlightRange as ex:
+    ...     print(ex)
+    Invalid highlight range: 5 - 3
     """
     def __init__(self, lower_bound, upper_bound):
         self.lower_bound = lower_bound
@@ -249,10 +284,13 @@ class InvalidDateFormat(HL7apyException):
     Raised when the output format for a :class:`hl7apy.base_datatypes.DateTimeDataType` is not valid
 
     >>> from hl7apy.v2_5 import DTM
-    >>> DTM(value='10102013', out_format="%d%m%Y")
-    Traceback (most recent call last):
-    ...
-    InvalidDateFormat: Invalid date format: %d%m%Y
+    >>> from hl7apy.exceptions import InvalidDateFormat
+    >>> try:
+    ...     DTM(value='10102013', out_format="%d%m%Y")
+    ...     raise AssertionError('InvalidDateFormat exception was not raised')
+    ... except InvalidDateFormat as ex:
+    ...     print(ex)
+    Invalid date format: %d%m%Y
     """
     def __init__(self, out_format):
         self.format = out_format
@@ -266,10 +304,13 @@ class InvalidDateOffset(HL7apyException):
     Raised when the offset for a :class:`TM` or :class:`hl7apy.base_datatypes.DTM` is not valid
 
     >>> from hl7apy.v2_5 import DTM
-    >>> DTM(value='20131010', out_format="%Y%m%d", offset='+1300')
-    Traceback (most recent call last):
-    ...
-    InvalidDateOffset: Invalid date offset: +1300
+    >>> from hl7apy.exceptions import InvalidDateOffset
+    >>> try:
+    ...     DTM(value='20131010', out_format="%Y%m%d", offset='+1300')
+    ...     raise AssertionError('InvalidDateOffset exception was not raised')
+    ... except InvalidDateOffset as ex:
+    ...     print(ex)
+    Invalid date offset: +1300
     """
     def __init__(self, offset):
         self.offset = offset
@@ -283,11 +324,14 @@ class InvalidMicrosecondsPrecision(HL7apyException):
     Raised when the microseconds precision of a TM or DTM oject is not between 1 and 4
 
     >>> from hl7apy.v2_5 import get_base_datatypes
+    >>> from hl7apy.exceptions import InvalidMicrosecondsPrecision
     >>> DTM = get_base_datatypes()['DTM']
-    >>> DTM(value='20131010', microsec_precision=5)
-    Traceback (most recent call last):
-    ...
-    InvalidMicrosecondsPrecision: Invalid microseconds precision. It must be between 1 and 4
+    >>> try:
+    ...     DTM(value='20131010', microsec_precision=5)
+    ...     raise AssertionError('InvalidMicrosecondsPrecision exception was not raised')
+    ... except InvalidMicrosecondsPrecision as ex:
+    ...     print(ex)
+    Invalid microseconds precision. It must be between 1 and 4
     """
 
     def __str__(self):
@@ -299,15 +343,19 @@ class InvalidEncodingChars(HL7apyException):
     Raised when the encoding chars specified is not a correct set of HL7 encoding chars
 
     >>> from hl7apy.core import Message
+    >>> from hl7apy.exceptions import InvalidEncodingChars
     >>> encoding_chars = {'GROUP': '\\r', 'SEGMENT': '\\r', 'COMPONENT': '^', \
                           'SUBCOMPONENT': '&', 'REPETITION': '~', 'ESCAPE': '\\\\'}
-    >>> m = Message('ADT_A01', encoding_chars=encoding_chars)
-    Traceback (most recent call last):
-    ...
-    InvalidEncodingChars: Missing required encoding chars
+    >>> try:
+    ...     m = Message('ADT_A01', encoding_chars=encoding_chars)
+    ...     raise AssertionError('InvalidEncodingChars exception was not raised')
+    ... except InvalidEncodingChars as ex:
+    ...     print(ex)
+    Missing required encoding chars
     """
     def __str__(self):
-        return self.message if self.message else 'Invalid encoding chars'
+        message = getattr(self, 'message', self.args[0])
+        return message if message else 'Invalid encoding chars'
 
 
 class MessageProfileNotFound(HL7apyException):

--- a/hl7apy/factories.py
+++ b/hl7apy/factories.py
@@ -97,7 +97,7 @@ def datatype_factory(datatype, value, version=None, validation_level=None):
         return factory(value, validation_level=validation_level)
     except KeyError:
         raise InvalidDataType(datatype)
-    except ValueError, e:
+    except ValueError as e:
         if Validator.is_strict(validation_level):
             raise e
         # TODO: Do we really want this? In that case the parent's datatype must be changed accordingly

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -20,6 +20,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import re
+import sys
 
 from hl7apy import get_default_encoding_chars, get_default_version, \
     get_default_validation_level, check_version, check_encoding_chars, check_validation_level
@@ -27,6 +28,12 @@ from hl7apy.consts import N_SEPS
 from hl7apy.core import is_base_datatype, Message, Group, Segment, Field, Component, SubComponent
 from hl7apy.exceptions import InvalidName, ParserError, InvalidEncodingChars, MessageProfileNotFound
 from hl7apy.validation import Validator
+
+
+if sys.version_info[0] <= 2:
+    range_func = xrange
+else:
+    range_func = range
 
 
 def parse_message(message, validation_level=None, find_groups=True, message_profile=None, report_file=None,
@@ -55,11 +62,11 @@ def parse_message(message, validation_level=None, find_groups=True, message_prof
     >>> message = "MSH|^~\&|GHH_ADT||||20080115153000||OML^O33^OML_O33|0123456789|P|2.5||||AL\\rPID|1||" \
     "566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004|||M\\r"
     >>> m = parse_message(message)
-    >>> print m
+    >>> print(m)
     <Message OML_O33>
-    >>> print m.msh.sending_application.to_er7()
+    >>> print(m.msh.sending_application.to_er7())
     GHH_ADT
-    >>> print m.children
+    >>> print(m.children)
     [<Segment MSH>, <Group OML_O33_PATIENT>]
     """
     message = message.lstrip()
@@ -122,7 +129,7 @@ def parse_segments(text, version=None, encoding_chars=None, validation_level=Non
 
     >>> segments = "EVN||20080115153000||||20080114003000\\rPID|1||566-554-3423^^^GHH^MR||EVERYMAN^ADAM^A|||M|||" \
     "2222 HOME STREET^^ANN ARBOR^MI^^USA||555-555-2004|||M\\r"
-    >>> print parse_segments(segments)
+    >>> print(parse_segments(segments))
     [<Segment EVN>, <Segment PID>]
     """
     version = _get_version(version)
@@ -174,9 +181,9 @@ def parse_segment(text, version=None, encoding_chars=None, validation_level=None
 
     >>> segment = "EVN||20080115153000||||20080114003000"
     >>> s =  parse_segment(segment)
-    >>> print s
+    >>> print(s)
     <Segment EVN>
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     EVN||20080115153000||||20080114003000
     """
     version = _get_version(version)
@@ -227,16 +234,16 @@ def parse_fields(text, name_prefix=None, version=None, encoding_chars=None, vali
 
     >>> fields = "1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA"
     >>> nk1_fields = parse_fields(fields, name_prefix="NK1")
-    >>> print nk1_fields
+    >>> print(nk1_fields)
     [<Field NK1_1 (SET_ID_NK1) of type SI>, <Field NK1_2 (NAME) of type XPN>, <Field NK1_3 (RELATIONSHIP) of type CE>, \
 <Field NK1_4 (ADDRESS) of type XAD>]
     >>> s = Segment("NK1")
     >>> s.children = nk1_fields
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     NK1|1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA
     >>> unknown_fields = parse_fields(fields)
     >>> s.children = unknown_fields
-    >>> print s.to_er7()
+    >>> print(s.to_er7())
     NK1||||||||||||||||||||||||||||||||||||||||1|NUCLEAR^NELDA^W|SPO|2222 HOME STREET^^ANN ARBOR^MI^^USA
     """
     version = _get_version(version)
@@ -306,14 +313,14 @@ def parse_field(text, name=None, version=None, encoding_chars=None, validation_l
 
     >>> field = "NUCLEAR^NELDA^W"
     >>> nk1_2 = parse_field(field, name="NK1_2")
-    >>> print nk1_2
+    >>> print(nk1_2)
     <Field NK1_2 (NAME) of type XPN>
-    >>> print nk1_2.to_er7()
+    >>> print(nk1_2.to_er7())
     NUCLEAR^NELDA^W
     >>> unknown = parse_field(field)
-    >>> print unknown
+    >>> print(unknown)
     <Field of type None>
-    >>> print unknown.to_er7()
+    >>> print(unknown.to_er7())
     NUCLEAR^NELDA^W
     """
     version = _get_version(version)
@@ -376,11 +383,11 @@ def parse_components(text, field_datatype='ST', version=None, encoding_chars=Non
 
     >>> components = "NUCLEAR^NELDA^W^^TEST"
     >>> xpn = parse_components(components, field_datatype="XPN")
-    >>> print xpn
+    >>> print(xpn)
     [<Component XPN_1 (FAMILY_NAME) of type FN>, <Component XPN_2 (GIVEN_NAME) of type ST>, \
 <Component XPN_3 (SECOND_AND_FURTHER_GIVEN_NAMES_OR_INITIALS_THEREOF) of type ST>, \
 <Component XPN_5 (PREFIX_E_G_DR) of type ST>]
-    >>> print parse_components(components)
+    >>> print(parse_components(components))
     [<Component ST (None) of type ST>, <Component ST (None) of type ST>, <Component ST (None) of type ST>, \
 <Component ST (None) of type ST>, <Component ST (None) of type ST>]
     """
@@ -450,11 +457,11 @@ def parse_component(text, name=None, datatype='ST', version=None, encoding_chars
 
     >>> component = "GATEWAY&1.3.6.1.4.1.21367.2011.2.5.17"
     >>> cx_4 = parse_component(component, name="CX_4")
-    >>> print cx_4
+    >>> print(cx_4)
     <Component CX_4 (ASSIGNING_AUTHORITY) of type None>
-    >>> print cx_4.to_er7()
+    >>> print(cx_4.to_er7())
     GATEWAY&1.3.6.1.4.1.21367.2011.2.5.17
-    >>> print parse_component(component)
+    >>> print(parse_component(component))
     <Component ST (None) of type None>
     """
     version = _get_version(version)
@@ -506,17 +513,17 @@ def parse_subcomponents(text, component_datatype='ST', version=None, encoding_ch
 
     >>> subcomponents= "ID&TEST&&AHAH"
     >>> cwe = parse_subcomponents(subcomponents, component_datatype="CWE")
-    >>> print cwe
+    >>> print(cwe)
     [<SubComponent CWE_1>, <SubComponent CWE_2>, <SubComponent CWE_4>]
     >>> c = Component(datatype='CWE')
     >>> c.children = cwe
-    >>> print c.to_er7()
+    >>> print(c.to_er7())
     ID&TEST&&AHAH
     >>> subs = parse_subcomponents(subcomponents)
-    >>> print subs
+    >>> print(subs)
     [<SubComponent ST>, <SubComponent ST>, <SubComponent ST>, <SubComponent ST>]
     >>> c.children = subs
-    >>> print c.to_er7()
+    >>> print(c.to_er7())
     &&&&&&&&&ID&TEST&&AHAH
     """
     version = _get_version(version)
@@ -668,7 +675,7 @@ def create_groups(message, children, validation_level=None):
     # for each segment found in the message...
     for c in children:
         found = -1
-        for x in xrange(len(search_data['structures'])):
+        for x in range_func(len(search_data['structures'])):
             found = _find_group(c, search_data, validation_level)
             # group not found at the current level, go back to the previous level
             if found == -1:

--- a/hl7apy/v2_2/__init__.py
+++ b/hl7apy/v2_2/__init__.py
@@ -21,11 +21,11 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3/__init__.py
+++ b/hl7apy/v2_3/__init__.py
@@ -21,11 +21,11 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_3_1/__init__.py
+++ b/hl7apy/v2_3_1/__init__.py
@@ -21,12 +21,12 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_4/__init__.py
+++ b/hl7apy/v2_4/__init__.py
@@ -21,12 +21,12 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5/__init__.py
+++ b/hl7apy/v2_5/__init__.py
@@ -21,12 +21,12 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_5_1/__init__.py
+++ b/hl7apy/v2_5_1/__init__.py
@@ -21,12 +21,12 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.exceptions import ChildNotFound
 

--- a/hl7apy/v2_6/__init__.py
+++ b/hl7apy/v2_6/__init__.py
@@ -21,12 +21,12 @@
 
 import importlib
 
-from messages import MESSAGES
-from segments import SEGMENTS
-from fields import FIELDS
-from datatypes import DATATYPES
-from groups import GROUPS
-from tables import TABLES
+from .messages import MESSAGES
+from .segments import SEGMENTS
+from .fields import FIELDS
+from .datatypes import DATATYPES
+from .groups import GROUPS
+from .tables import TABLES
 
 from hl7apy.v2_6.base_datatypes import ST as _ST26
 from hl7apy.exceptions import ChildNotFound

--- a/tests/test_mllp.py
+++ b/tests/test_mllp.py
@@ -20,11 +20,18 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import socket
+import sys
 import unittest
 from threading import Thread
 
 from hl7apy.mllp import MLLPServer, AbstractHandler
 from hl7apy.mllp import InvalidHL7Message, UnsupportedMessageType
+
+
+if sys.version_info[0] <= 2:
+    text_type = unicode
+else:
+    text_type = str
 
 
 HOST = 'localhost'
@@ -113,6 +120,8 @@ class TestMLLPWithErrorHandler(unittest.TestCase):
         stop_server(cls.server, cls.thread)
 
     def _client(self, msg):
+        if isinstance(msg, text_type):
+            msg = msg.encode()
         # establish the connection
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
@@ -123,7 +132,7 @@ class TestMLLPWithErrorHandler(unittest.TestCase):
                 received = sock.recv(1)
                 if not received:
                     break
-                res.append(received)
+                res.append(received.decode())
         finally:
             sock.close()
 
@@ -169,6 +178,8 @@ class TestMLLPWithoutErrorHandler(unittest.TestCase):
         stop_server(cls.server, cls.thread)
 
     def _client(self, msg):
+        if isinstance(msg, text_type):
+            msg = msg.encode()
         # establish the connection
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
@@ -179,7 +190,7 @@ class TestMLLPWithoutErrorHandler(unittest.TestCase):
                 received = sock.recv(1)
                 if not received:
                     break
-                res.append(received)
+                res.append(received.decode())
         finally:
             sock.close()
 

--- a/utils/hl7apy_profile_parser
+++ b/utils/hl7apy_profile_parser
@@ -20,13 +20,20 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
 import os
 import re
 from optparse import OptionParser
 from lxml import objectify
 import collections
-import cPickle
+
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 
 
 class ProfileParser(object):
@@ -129,8 +136,8 @@ class ProfileParser(object):
         try:
             if not os.path.exists(self.output_path):
                 os.mkdir(self.output_path)
-        except Exception, ex:
-            print "Error occurred while saving the output to: ", self.output_path, ex
+        except Exception as ex:
+            print("Error occurred while saving the output to: ", self.output_path, ex, sep=' ')
             sys.exit(1)
 
         if os.path.isdir(self.input_path):
@@ -145,7 +152,7 @@ class ProfileParser(object):
             content = self.parse_profile(f)
             file_path = os.path.join(self.output_path, filename)
             with open(file_path, "wb") as output_file:
-                cPickle.dump(dict(content), output_file)
+                pickle.dump(dict(content), output_file)
 
     def parse_profile(self, profile_file):
         """
@@ -157,14 +164,14 @@ class ProfileParser(object):
             schema_path = os.path.join(self.input_path, profile_file)
             with open(schema_path) as xml_file:
                 data = xml_file.read()
-        except Exception, ex:
-            print "Error occurred while opening the message profile file: ", ex
+        except Exception as ex:
+            print("Error occurred while opening the message profile file: ", ex, sep=' ')
             sys.exit(1)
 
         try:
             f = objectify.XML(data)
-        except Exception, ex:
-            print "Invalid XML file: ", profile_file, ex
+        except Exception as ex:
+            print("Invalid XML file: ", profile_file, ex, sep=' ')
             sys.exit(1)
 
         message_structure = f.HL7v2xStaticDef.get('MsgStructID')

--- a/utils/xsd_parser.py
+++ b/utils/xsd_parser.py
@@ -19,12 +19,21 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
 import sys
 import os
 import re
 from optparse import OptionParser
 from lxml import objectify
 import pprint
+
+
+if sys.version_info[0] <= 2:
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+else:
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
 
 
 class XSDParser(object):
@@ -34,8 +43,8 @@ class XSDParser(object):
         self.output_path = output_path
         try:
             methods = [getattr(self, p) for p in to_parse]
-        except Exception, ex:
-            print "Invalid parsing options.", ex
+        except Exception as ex:
+            print("Invalid parsing options.", ex, sep=' ')
             sys.exit(1)
         for m in methods:
             m()
@@ -64,7 +73,7 @@ class XSDParser(object):
         parse_res = self.parse_schema("datatypes.xsd")
         content, types = parse_res[0], parse_res[2]
         content.update(types)
-        content = {k: v for k, v in content.iteritems() if not k.endswith("_CONTENT")}
+        content = {k: v for k, v in iteritems(content) if not k.endswith("_CONTENT")}
         self.generate_module("datatypes.py", content)
 
     def parse_messages(self):
@@ -81,7 +90,7 @@ class XSDParser(object):
             message, ext = os.path.splitext(f)
             content = self.parse_schema(f)[0]
             message_def[message] = content[message.upper()]
-            groups.update(g for g in content.iteritems() if g[0] != message)
+            groups.update(g for g in iteritems(content) if g[0] != message)
         self.generate_module("messages.py", message_def)
         self.generate_module("groups.py", groups)
 
@@ -95,14 +104,14 @@ class XSDParser(object):
             schema_path = os.path.join(self.input_path, schema_file)
             with open(schema_path) as xml_file:
                 data = xml_file.read()
-        except Exception, ex:
-            print "Error occurred while opening the XSD file: ", ex
+        except Exception as ex:
+            print("Error occurred while opening the XSD file: ", ex, sep=' ')
             sys.exit(1)
 
         try:
             f = objectify.XML(data)
-        except Exception, ex:
-            print "Invalid XSD file: ", schema_file, ex
+        except Exception as ex:
+            print("Invalid XSD file: ", schema_file, ex, sep=' ')
             sys.exit(1)
 
         try:
@@ -112,7 +121,7 @@ class XSDParser(object):
 
         try:
             types = [Node(c).to_dict() for c in f.complexType]
-        except Exception, ex:
+        except Exception as ex:
             complex_types = {}  # no xsd:complexType found,
         else:
             complex_types = dict((node.get('name'), node.get('content')) for node in types)
@@ -125,13 +134,13 @@ class XSDParser(object):
                     if content.get('type') == 'annotation':
                         content = node['content']
                 elements[node.get('name')] = content
-        except Exception, ex:
+        except Exception as ex:
             elements = {}  # no xsd:element found
         return elements, includes, complex_types
 
     def reduce_content_size(self, content):
         to_delete = []
-        for key, value in content.iteritems():
+        for key, value in iteritems(content):
             if value is not None:
                 if value['type'] in ('sequence', 'choice') and value.get('content'):
                     try:
@@ -163,8 +172,8 @@ class XSDParser(object):
             with open(module_path, "w") as output_file:
                 output_file.write("{0} = ".format(constant_name.upper()))
                 pprint.pprint(module_content, output_file)
-        except Exception, ex:
-            print "Error occurred while saving the output to: ", module_name, ex
+        except Exception as ex:
+            print("Error occurred while saving the output to: ", module_name, ex, sep=' ')
             sys.exit(1)
 
 


### PR DESCRIPTION
Another attempt at making the code compatible with Python 3. The six compatibility library has not been added as a dependency, but the changes follow six's conventions. We used PyCharm's code inspection tool to find (hopefully) all of the compatibility issues in code base.
All of the tests are passing including the MLLP and doctests.