### PR TITLE
Drop official support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation can be found [here](http://crs4.github.io/hl7apy/).
 Installation
 ------------
 
-HL7apy is platform independent and supports Python 2.7 and Python 3.4, 3.5, 3.6, 3.7
+HL7apy is platform independent and supports Python 2.7 and Python 3.5, 3.6, 3.7
 
 To install it get the latest release from [GitHub](https://github.com/crs4/hl7apy/releases) and launch the following command:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ This project is not affiliated with the HL7 organization: the library is just co
 Installation
 ============
 
-HL7apy is platform independent and supports Python 2.7 and Python 3.4, 3.5, 3.6, 3.7
+HL7apy is platform independent and supports Python 2.7 and Python 3.5, 3.6, 3.7
 
 To install it get the latest release from `GitHub <https://github.com/crs4/hl7apy/releases>`_ and launch the following
 command:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py35,py36,py37
 
 [testenv]
 deps=


### PR DESCRIPTION
Python 3.4 is 6 years old at this point