### PR TITLE
Allow handlers to access server

### DIFF
--- a/hl7apy/mllp.py
+++ b/hl7apy/mllp.py
@@ -122,6 +122,7 @@ class _MLLPRequestHandler(StreamRequestHandler):
                 raise UnsupportedMessageType(msg_type)
 
             h = handler(msg, *args)
+            h.server = self
             return h.reply()
         except Exception as e:
             try:
@@ -130,6 +131,7 @@ class _MLLPRequestHandler(StreamRequestHandler):
                 raise e
             else:
                 h = err_handler(e, msg, *args)
+                h.server = self
                 return h.reply()
 
 
@@ -174,6 +176,8 @@ class AbstractHandler(object):
 
         :param message: the ER7-formatted HL7 message to handle
     """
+    server = None
+
     def __init__(self, message):
         self.incoming_message = message
 


### PR DESCRIPTION
This enables handlers to access attributes of the _MLLPServer instance.

My use case is that my server parses header data and sets an attribute on the server that I need to access within my handlers.

```python
class MyCustomMllpRequestHandler(mllp._MLLPRequestHandler):
    def handle(self):
        self.config = parse_headers(self.request)
        # ...

class MyAdtHandler(mllp.AbstractHandler):
    def reply(self):
        config = self.server.config  # desired API
        # ...
```