### PR TITLE
fix: don't check sys.modules before dynamic import

### DIFF
--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -233,9 +233,7 @@ def load_library(version):
     """
     check_version(version)
     module_name = SUPPORTED_LIBRARIES[version]
-    lib = sys.modules.get(module_name)
-    if lib is None:
-        lib = importlib.import_module(module_name)
+    lib = importlib.import_module(module_name)
     return lib
 
 


### PR DESCRIPTION
1. `importlib.import_module` [already does this](https://github.com/python/cpython/blob/7d14fdb03c3e8384c01da1b21647ce837ed6a29c/Lib/importlib/_bootstrap.py#L1033-L1046).
2. Moreover, you must acquire the import lock before checking sys.modules. `importlib.import_module` does this for you.

Fixes https://github.com/crs4/hl7apy/issues/6