### PR TITLE
fix: invalid escape sequence

### DIFF
--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -105,7 +105,7 @@ def _valid_child_name(child_name, expected_parent):
 def _valid_z_message_name(name):
     if name is None:
         return False
-    regex = '^z[a-z0-9]{2}_z[a-z0-9]{2}$'
+    regex = r'^z[a-z0-9]{2}_z[a-z0-9]{2}$'
     return re.match(regex, name, re.IGNORECASE) is not None
 
 
@@ -114,7 +114,7 @@ def _valid_z_segment_name(name):
 
 
 def _valid_z_field_name(name):
-    regex = '^z[a-z1-9]{2}_\d+$'
+    regex = r'^z[a-z1-9]{2}_\d+$'
     return re.match(regex, name, re.IGNORECASE) is not None
 
 

--- a/hl7apy/parser.py
+++ b/hl7apy/parser.py
@@ -634,7 +634,7 @@ def parse_subcomponent(text, name=None, datatype='ST', version=None, validation_
 
 
 def _split_msh(content):
-    m = re.match("^MSH(?P<field_sep>\S)", content)
+    m = re.match(r"^MSH(?P<field_sep>\S)", content)
     if m is not None:  # if the regular expression matches, it is an HL7 message
         field_sep = m.group('field_sep')  # get the field separator (first char after MSH)
         msh = content.split("\r", 1)[0]  # get the first segment

--- a/hl7apy/utils.py
+++ b/hl7apy/utils.py
@@ -113,7 +113,7 @@ def get_datetime_info(value):
 
 
 def _split_offset(value):
-    offset = re.search('\d*((\+(1[0-4]|0[0-9])|(-(1[0-2]|0[0-9])))([0-5][0-9]))$', value)
+    offset = re.search(r'\d*((\+(1[0-4]|0[0-9])|(-(1[0-2]|0[0-9])))([0-5][0-9]))$', value)
     if offset:
         offset = offset.groups()[0]
         return value.replace(offset, ''), offset

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -93,9 +93,9 @@ class TestValidation(unittest.TestCase):
         with open(self.report_file, 'r') as f:
             s = f.read()
         if error_type == 'ERROR':
-            regex = 'Error:.*'
+            regex = r'Error:.*'
         elif error_type == 'WARNING':
-            regex = 'Warning:.*'
+            regex = r'Warning:.*'
 
         self.assertTrue(re.search(regex, s))
 
@@ -414,9 +414,9 @@ class TestMessageProfile(unittest.TestCase):
         with open(self.report_file, 'r') as f:
             s = f.read()
         if error_type == 'ERROR':
-            regex = 'Error:.*'
+            regex = r'Error:.*'
         elif error_type == 'WARNING':
-            regex = 'Warning:.*'
+            regex = r'Warning:.*'
         else:
             return
 

--- a/utils/test_parsing_message.py
+++ b/utils/test_parsing_message.py
@@ -71,7 +71,7 @@ def natural_sort(list_of_lists, index=0):
         return int(text) if text.isdigit() else text.lower()
 
     def alphanum_key(key):
-        return [convert(c) for c in re.split('([0-9]+)', key[index])]
+        return [convert(c) for c in re.split(r'([0-9]+)', key[index])]
 
     return sorted(list_of_lists, key=alphanum_key)
 


### PR DESCRIPTION
Normal strings regex produce "SyntaxWarning: invalid escape sequence" for special chars like "\&", "\d" and "\S".
Transform those normal strings to raw strings to fix this.