### PR TITLE
Enhanced .validate()

### DIFF
--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -740,15 +740,16 @@ class Element(object):
 
         return separator.join(s)
 
-    def validate(self, report_file=None):
+    def validate(self, report_file=None, return_errors=False):
         """
         Validate the HL7 element using the :attr:`STRICT <hl7apy.consts.VALIDATION_LEVEL.STRICT>` validation
         level. It calls the :func:`Validator.validate <hl7apy.validation.Validator.validate>` method passing
         the reference used in the instantiation of the element.
 
         :param: report_file: the report file to pass to the validator
+        :param: return_errors: return errors and warnings instead of raising
         """
-        return Validator.validate(self, reference=self.reference, report_file=report_file)
+        return Validator.validate(self, reference=self.reference, report_file=report_file, return_errors=return_errors)
 
     def is_z_element(self):
         return False

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,6 +21,7 @@
 
 from __future__ import absolute_import
 
+from io import StringIO
 import os
 import re
 import sys
@@ -388,6 +389,33 @@ class TestValidation(unittest.TestCase):
         parsed_s = parse_segment(s, version='2.7')
         self.assertRaises(ValidationError, parsed_s.validate)
 
+    def test_validate_with_param_report_file_as_string_io(self):
+        """
+        Tests that, if you use stringIO to validate, warning and errors are written there
+        """
+        string_io = StringIO()
+        msg = self._create_message(self.oml_o33)
+        self.assertTrue(msg.validate(report_file=string_io))
+        self.assertGreater(string_io.tell(), 0)
+
+    def test_validate_with_param_return_errors(self):
+        """
+        Tests message is valid with warnings using return_errors=True
+        """
+        msg = self._create_message(self.oml_o33)
+        errors_and_warnings = msg.validate(return_errors=True)
+        self.assertTrue(errors_and_warnings.is_valid)
+        self.assertEqual(len(errors_and_warnings.warnings), 2)
+
+    def test_well_structured_message_using_return_error(self):
+        """
+        Tests that a valid message is validated using return_error
+        """
+        msg = self._create_message(self.adt_a01)
+        errors_and_warnings = msg.validate(return_errors=True)
+        self.assertTrue(errors_and_warnings.is_valid)
+        self.assertEqual(len(errors_and_warnings.errors), 0)
+        self.assertEqual(len(errors_and_warnings.warnings), 0)
 
 class TestMessageProfile(unittest.TestCase):
 


### PR DESCRIPTION
While using hl7api, we had 2 different needs:
1. the `report_file` parameter of .validate() need to support also file-like object (io.StringIO/io.BytesIO in our case) that are not necessarily filesystem files.
2. Cases where we needed a full report of warnings and errors returned by the function, instead of raising just the 1st error.

So we modified .validate() adding the above mentioned backward-compatible error-handling and -reporting enhancements.


Co-authored-by: Massimiliano della Rovere <massimiliano.dellarovere@dedalus.com>
Co-authored-by: Jorge García Roca <jgarciaroca@dedalus.com>