### PR TITLE
fix(validator): Print expected datatype when a wrong datatype is found

### DIFF
--- a/hl7apy/validation.py
+++ b/hl7apy/validation.py
@@ -118,7 +118,7 @@ class Validator(object):
             ref_datatype = ref[2]
             if el.datatype != ref_datatype:
                 errs.append(ValidationError("Datatype {} is not correct for {}.{} (it must be {})".
-                                            format(el.datatype, el.parent.name, el.name, ref[1])))
+                                            format(el.datatype, el.parent.name, el.name, ref_datatype)))
 
         def _get_valid_children_info(ref):
             valid_children = {c[0] for c in ref[1]}


### PR DESCRIPTION
Fixes None being printed as the expected datatype