### PR TITLE
Update URLs that appear on PyPI

### DIFF
--- a/hl7apy/__init__.py
+++ b/hl7apy/__init__.py
@@ -42,7 +42,7 @@ from hl7apy.consts import DEFAULT_ENCODING_CHARS, DEFAULT_ENCODING_CHARS_27, DEF
 __author__ = 'Daniela Ghironi, Vittorio Meloni, Alessandro Sulis, Federico Caboni'
 __author_email__ = '<ghiron@gmail.com>, <vittorio.meloni@crs4.it>, <alessandro.sulis@crs4.it>, ' \
                    '<federico.caboni@me.com>'
-__url__ = 'http://crs4.github.io/hl7apy/'
+__url__ = 'https://crs4.github.io/hl7apy/'
 
 _DEFAULT_ENCODING_CHARS = DEFAULT_ENCODING_CHARS
 _DEFAULT_ENCODING_CHARS_27 = DEFAULT_ENCODING_CHARS_27

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     description=desc,
     long_description=long_desc,
     url=hl7apy.__url__,
-    download_url='http://sourceforge.net/projects/hl7apy/files/',
+    download_url='https://github.com/crs4/hl7apy',
     license='MIT License',
     keywords=['HL7', 'Health Level 7', 'healthcare', 'python'],
     classifiers=[


### PR DESCRIPTION
This updates the package metadata which appears on https://pypi.org/project/hl7apy/

- GitHub Pages supports HTTPS; it should be used over HTTP
- Since 1.3.3, this project is not distributed on SourceForge