### PR TITLE
fix(core): update content type to 'sequence' when Field changes to complex datatype. Fix of #144

### DIFF
--- a/hl7apy/core.py
+++ b/hl7apy/core.py
@@ -919,6 +919,7 @@ class SupportComplexDataType(Element):
                 datatype not in ('varies', None, self.datatype) and self.datatype is not None:
             reference = load_reference(datatype, 'Datatypes_Structs', self.version)
             new_ref = [ref_item for ref_item in self.reference]
+            new_ref[0] = 'sequence'
             new_ref[1] = reference
             new_ref[2] = datatype
             structure = ElementFinder.get_structure(self, new_ref)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1305,6 +1305,16 @@ class TestField(unittest.TestCase):
         self.assertEqual(f.cm_msg_1.value, 'SIU')
         self.assertEqual(f.cm_msg_2.value, 'S12')
 
+    def test_field_datatype_to_complex_serialization(self):
+        f = Field('OBX_5')
+        f.datatype = 'ED'
+        f.ed_1 = ''
+        f.ed_2 = 'IM'
+        f.ed_3 = 'JPEG'
+        f.ed_4 = 'Base64'
+        f.ed_5 = 'SomeData'
+        self.assertEqual(f.to_er7(), '^IM^JPEG^Base64^SomeData')
+
 
 class TestComponent(unittest.TestCase):
 


### PR DESCRIPTION
Problem: When setting a Field's datatype to a complex/composite datatype (e.g., ED, RP, CE), the serialization incorrectly produced empty output instead of the expected HL7 formatted string.

Example of the bug from #144:
```python
from hl7apy.core import Message

m = Message()
m.obx.obx_5.datatype = 'ED'
m.obx.obx_5.ed_1 = ''
m.obx.obx_5.ed_2 = 'IM'
m.obx.obx_5.ed_3 = 'JPEG'
m.obx.obx_5.ed_4 = 'Base64'
m.obx.obx_5.ed_5 = 'SomeData'

# Before fix: Produces "OBX|||||" (missing data)
# After fix:  Produces "OBX|||||^IM^JPEG^Base64^SomeData" (correct)
```


Root cause: According to the https://hl7-definition.caristix.com/v2/HL7v2.5/DataTypes/ED, this is explicitly a composite datatype containing multiple components.

When a Field's datatype is changed to a composite datatype, the code must update the field's content type from 'leaf' to 'sequence' to indicate it has a composite structure with multiple child components. This content type is used by ElementFinder._parse_structure() to determine whether to build the necessary ordered_children and
structure_by_name dictionaries

Bug was that the `SupportComplexDataType._set_datatype()` method was updating the children reference and datatype, but forgot to update the content type from 'leaf' to 'sequence'. This caused the serialization logic to skip building the structure dictionaries, resulting in empty output.

Fix is actually a one-line change – setting content type to 'sequence' for composite datatypes

This aligns with the existing CanBeVaries implementation (used by Components) which already sets 'sequence' for composite datatypes at initialization.

Also added single unit test to verify serialization works correctly.